### PR TITLE
Performance improvement of file sink on nexmark

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -436,10 +436,11 @@ public class RestClusterClient<T> implements ClusterClient<T> {
 
     @Override
     public CompletableFuture<Acknowledge> cancel(JobID jobID) {
-        JobCancellationMessageParameters params = new JobCancellationMessageParameters();
-        params.jobPathParameter.resolve(jobID);
-        params.terminationModeQueryParameter.resolve(
-                Collections.singletonList(TerminationModeQueryParameter.TerminationMode.CANCEL));
+        JobCancellationMessageParameters params =
+                new JobCancellationMessageParameters()
+                        .resolveJobId(jobID)
+                        .resolveTerminationMode(
+                                TerminationModeQueryParameter.TerminationMode.CANCEL);
         CompletableFuture<EmptyResponseBody> responseFuture =
                 sendRequest(JobCancellationHeaders.getInstance(), params);
         return responseFuture.thenApply(ignore -> Acknowledge.get());

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
@@ -293,11 +293,7 @@ public class RestClusterClientSavepointTriggerTest extends TestLogger {
 
         @Override
         protected CompletableFuture<TriggerResponse> handleRequest(
-                @Nonnull
-                        HandlerRequest<
-                                        SavepointTriggerRequestBody,
-                                        SavepointTriggerMessageParameters>
-                                request,
+                @Nonnull HandlerRequest<SavepointTriggerRequestBody> request,
                 @Nonnull DispatcherGateway gateway)
                 throws RestHandlerException {
 
@@ -324,7 +320,7 @@ public class RestClusterClientSavepointTriggerTest extends TestLogger {
 
         @Override
         protected CompletableFuture<AsynchronousOperationResult<SavepointInfo>> handleRequest(
-                @Nonnull HandlerRequest<EmptyRequestBody, SavepointStatusMessageParameters> request,
+                @Nonnull HandlerRequest<EmptyRequestBody> request,
                 @Nonnull DispatcherGateway gateway)
                 throws RestHandlerException {
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -274,7 +274,7 @@ public class RestClusterClientTest extends TestLogger {
 
         @Override
         protected CompletableFuture<JobSubmitResponseBody> handleRequest(
-                @Nonnull HandlerRequest<JobSubmitRequestBody, EmptyMessageParameters> request,
+                @Nonnull HandlerRequest<JobSubmitRequestBody> request,
                 @Nonnull DispatcherGateway gateway)
                 throws RestHandlerException {
             jobSubmitted = true;
@@ -293,7 +293,7 @@ public class RestClusterClientTest extends TestLogger {
 
         @Override
         protected CompletableFuture<EmptyResponseBody> handleRequest(
-                @Nonnull HandlerRequest<EmptyRequestBody, JobCancellationMessageParameters> request,
+                @Nonnull HandlerRequest<EmptyRequestBody> request,
                 @Nonnull DispatcherGateway gateway)
                 throws RestHandlerException {
             jobCanceled = true;
@@ -386,9 +386,7 @@ public class RestClusterClientTest extends TestLogger {
 
             @Override
             protected CompletableFuture<TriggerResponse> handleRequest(
-                    @Nonnull
-                            HandlerRequest<SavepointDisposalRequest, EmptyMessageParameters>
-                                    request,
+                    @Nonnull HandlerRequest<SavepointDisposalRequest> request,
                     @Nonnull DispatcherGateway gateway) {
                 assertThat(request.getRequestBody().getSavepointPath(), is(savepointPath));
                 return CompletableFuture.completedFuture(new TriggerResponse(triggerId));
@@ -412,11 +410,7 @@ public class RestClusterClientTest extends TestLogger {
             @Override
             protected CompletableFuture<AsynchronousOperationResult<AsynchronousOperationInfo>>
                     handleRequest(
-                            @Nonnull
-                                    HandlerRequest<
-                                                    EmptyRequestBody,
-                                                    SavepointDisposalStatusMessageParameters>
-                                            request,
+                            @Nonnull HandlerRequest<EmptyRequestBody> request,
                             @Nonnull DispatcherGateway gateway)
                             throws RestHandlerException {
                 final TriggerId actualTriggerId =
@@ -581,7 +575,7 @@ public class RestClusterClientTest extends TestLogger {
 
         @Override
         protected CompletableFuture<JobExecutionResultResponseBody> handleRequest(
-                @Nonnull HandlerRequest<EmptyRequestBody, JobMessageParameters> request,
+                @Nonnull HandlerRequest<EmptyRequestBody> request,
                 @Nonnull DispatcherGateway gateway) {
             if (jobExecutionResults.hasNext()) {
                 lastJobExecutionResult = jobExecutionResults.next();
@@ -755,7 +749,7 @@ public class RestClusterClientTest extends TestLogger {
 
         @Override
         protected CompletableFuture<JobSubmitResponseBody> handleRequest(
-                @Nonnull HandlerRequest<JobSubmitRequestBody, EmptyMessageParameters> request,
+                @Nonnull HandlerRequest<JobSubmitRequestBody> request,
                 @Nonnull DispatcherGateway gateway)
                 throws RestHandlerException {
             throw new RestHandlerException("expected", HttpResponseStatus.INTERNAL_SERVER_ERROR);
@@ -804,7 +798,7 @@ public class RestClusterClientTest extends TestLogger {
 
         @Override
         protected CompletableFuture<EmptyResponseBody> handleRequest(
-                @Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
+                @Nonnull HandlerRequest<EmptyRequestBody> request,
                 @Nonnull DispatcherGateway gateway)
                 throws RestHandlerException {
             final CompletableFuture<EmptyResponseBody> result = responseQueue.poll();
@@ -935,11 +929,7 @@ public class RestClusterClientTest extends TestLogger {
         @Override
         @SuppressWarnings("unchecked")
         protected CompletableFuture<ClientCoordinationResponseBody> handleRequest(
-                @Nonnull
-                        HandlerRequest<
-                                        ClientCoordinationRequestBody,
-                                        ClientCoordinationMessageParameters>
-                                request,
+                @Nonnull HandlerRequest<ClientCoordinationRequestBody> request,
                 @Nonnull DispatcherGateway gateway)
                 throws RestHandlerException {
             try {
@@ -989,7 +979,7 @@ public class RestClusterClientTest extends TestLogger {
 
         @Override
         protected CompletableFuture<JobAccumulatorsInfo> handleRequest(
-                @Nonnull HandlerRequest<EmptyRequestBody, JobAccumulatorsMessageParameters> request,
+                @Nonnull HandlerRequest<EmptyRequestBody> request,
                 @Nonnull DispatcherGateway gateway)
                 throws RestHandlerException {
             JobAccumulatorsInfo accumulatorsInfo;
@@ -1046,7 +1036,7 @@ public class RestClusterClientTest extends TestLogger {
 
         @Override
         protected CompletableFuture<MultipleJobsDetails> handleRequest(
-                @Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
+                @Nonnull HandlerRequest<EmptyRequestBody> request,
                 @Nonnull DispatcherGateway gateway)
                 throws RestHandlerException {
             JobDetails running =
@@ -1073,7 +1063,7 @@ public class RestClusterClientTest extends TestLogger {
 
         @Override
         protected CompletableFuture<JobDetailsInfo> handleRequest(
-                @Nonnull HandlerRequest<EmptyRequestBody, JobMessageParameters> request,
+                @Nonnull HandlerRequest<EmptyRequestBody> request,
                 @Nonnull DispatcherGateway gateway)
                 throws RestHandlerException {
             if (!jobDetailsInfo.hasNext()) {

--- a/flink-rpc/flink-rpc-akka-loader/pom.xml
+++ b/flink-rpc/flink-rpc-akka-loader/pom.xml
@@ -78,7 +78,7 @@ under the License.
 				<executions>
 					<execution>
 						<id>copy-rpc-akka-jars</id>
-						<phase>process-resources</phase>
+						<phase>package</phase>
 						<goals>
 							<goal>copy</goal>
 						</goals>

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandler.java
@@ -66,7 +66,7 @@ public class JarDeleteHandler
 
     @Override
     protected CompletableFuture<EmptyResponseBody> handleRequest(
-            @Nonnull final HandlerRequest<EmptyRequestBody, JarDeleteMessageParameters> request,
+            @Nonnull final HandlerRequest<EmptyRequestBody> request,
             @Nonnull final RestfulGateway gateway)
             throws RestHandlerException {
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
@@ -83,8 +83,7 @@ public class JarListHandler
 
     @Override
     protected CompletableFuture<JarListInfo> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
-            @Nonnull RestfulGateway gateway)
+            @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
             throws RestHandlerException {
         final String localAddress;
         Preconditions.checkState(localAddressFuture.isDone());

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHandler.java
@@ -94,7 +94,7 @@ public class JarPlanHandler
 
     @Override
     protected CompletableFuture<JobPlanInfo> handleRequest(
-            @Nonnull final HandlerRequest<JarPlanRequestBody, JarPlanMessageParameters> request,
+            @Nonnull final HandlerRequest<JarPlanRequestBody> request,
             @Nonnull final RestfulGateway gateway)
             throws RestHandlerException {
         final JarHandlerContext context = JarHandlerContext.fromRequest(request, jarDir, log);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
@@ -83,7 +83,7 @@ public class JarRunHandler
 
     @Override
     protected CompletableFuture<JarRunResponseBody> handleRequest(
-            @Nonnull final HandlerRequest<JarRunRequestBody, JarRunMessageParameters> request,
+            @Nonnull final HandlerRequest<JarRunRequestBody> request,
             @Nonnull final DispatcherGateway gateway)
             throws RestHandlerException {
 
@@ -121,8 +121,7 @@ public class JarRunHandler
     }
 
     private SavepointRestoreSettings getSavepointRestoreSettings(
-            final @Nonnull HandlerRequest<JarRunRequestBody, JarRunMessageParameters> request)
-            throws RestHandlerException {
+            final @Nonnull HandlerRequest<JarRunRequestBody> request) throws RestHandlerException {
 
         final JarRunRequestBody requestBody = request.getRequestBody();
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHandler.java
@@ -69,7 +69,7 @@ public class JarUploadHandler
 
     @Override
     protected CompletableFuture<JarUploadResponseBody> handleRequest(
-            @Nonnull final HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
+            @Nonnull final HandlerRequest<EmptyRequestBody> request,
             @Nonnull final RestfulGateway gateway)
             throws RestHandlerException {
         Collection<File> uploadedFiles = request.getUploadedFiles();

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/utils/JarHandlerUtils.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/utils/JarHandlerUtils.java
@@ -91,7 +91,7 @@ public class JarHandlerUtils {
         }
 
         public static <R extends JarRequestBody> JarHandlerContext fromRequest(
-                @Nonnull final HandlerRequest<R, ?> request,
+                @Nonnull final HandlerRequest<R> request,
                 @Nonnull final Path jarDir,
                 @Nonnull final Logger log)
                 throws RestHandlerException {
@@ -188,7 +188,7 @@ public class JarHandlerUtils {
 
     /** Parse program arguments in jar run or plan request. */
     private static <R extends JarRequestBody, M extends MessageParameters>
-            List<String> getProgramArgs(HandlerRequest<R, M> request, Logger log)
+            List<String> getProgramArgs(HandlerRequest<R> request, Logger log)
                     throws RestHandlerException {
         JarRequestBody requestBody = request.getRequestBody();
         @SuppressWarnings("deprecation")

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
@@ -136,11 +136,12 @@ public class JarDeleteHandlerTest extends TestLogger {
 
     private static HandlerRequest<EmptyRequestBody, JarDeleteMessageParameters> createRequest(
             final String jarFileName) throws HandlerRequestException {
-        return new HandlerRequest<>(
+        return HandlerRequest.resolveParametersAndCreate(
                 EmptyRequestBody.getInstance(),
                 new JarDeleteMessageParameters(),
                 Collections.singletonMap(JarIdPathParameter.KEY, jarFileName),
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                Collections.emptyList());
     }
 
     private void makeJarDirReadOnly() {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
@@ -85,8 +85,7 @@ public class JarDeleteHandlerTest extends TestLogger {
     public void testDeleteJarById() throws Exception {
         assertThat(Files.exists(jarDir.resolve(TEST_JAR_NAME)), equalTo(true));
 
-        final HandlerRequest<EmptyRequestBody, JarDeleteMessageParameters> request =
-                createRequest(TEST_JAR_NAME);
+        final HandlerRequest<EmptyRequestBody> request = createRequest(TEST_JAR_NAME);
         jarDeleteHandler.handleRequest(request, restfulGateway).get();
 
         assertThat(Files.exists(jarDir.resolve(TEST_JAR_NAME)), equalTo(false));
@@ -94,8 +93,7 @@ public class JarDeleteHandlerTest extends TestLogger {
 
     @Test
     public void testDeleteUnknownJar() throws Exception {
-        final HandlerRequest<EmptyRequestBody, JarDeleteMessageParameters> request =
-                createRequest("doesnotexist.jar");
+        final HandlerRequest<EmptyRequestBody> request = createRequest("doesnotexist.jar");
         try {
             jarDeleteHandler.handleRequest(request, restfulGateway).get();
         } catch (final ExecutionException e) {
@@ -118,8 +116,7 @@ public class JarDeleteHandlerTest extends TestLogger {
     public void testFailedDelete() throws Exception {
         makeJarDirReadOnly();
 
-        final HandlerRequest<EmptyRequestBody, JarDeleteMessageParameters> request =
-                createRequest(TEST_JAR_NAME);
+        final HandlerRequest<EmptyRequestBody> request = createRequest(TEST_JAR_NAME);
         try {
             jarDeleteHandler.handleRequest(request, restfulGateway).get();
         } catch (final ExecutionException e) {
@@ -134,8 +131,8 @@ public class JarDeleteHandlerTest extends TestLogger {
         }
     }
 
-    private static HandlerRequest<EmptyRequestBody, JarDeleteMessageParameters> createRequest(
-            final String jarFileName) throws HandlerRequestException {
+    private static HandlerRequest<EmptyRequestBody> createRequest(final String jarFileName)
+            throws HandlerRequestException {
         return HandlerRequest.resolveParametersAndCreate(
                 EmptyRequestBody.getInstance(),
                 new JarDeleteMessageParameters(),

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
@@ -291,7 +291,7 @@ public abstract class JarHandlerParameterTest<
                                         MessageParameter::getKey,
                                         JarHandlerParameterTest::getValuesAsString));
 
-        return new HandlerRequest<>(
+        return HandlerRequest.resolveParametersAndCreate(
                 requestBody,
                 unresolvedMessageParameters,
                 Collections.singletonMap(JarIdPathParameter.KEY, jar.getFileName().toString()),

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
@@ -206,7 +206,7 @@ public abstract class JarHandlerParameterTest<
     public void testProvideJobId() throws Exception {
         JobID jobId = new JobID();
 
-        HandlerRequest<REQB, M> request =
+        HandlerRequest<REQB> request =
                 createRequest(
                         getJarRequestBodyWithJobId(jobId),
                         getUnresolvedJarMessageParameters(),
@@ -279,7 +279,7 @@ public abstract class JarHandlerParameterTest<
     }
 
     protected static <REQB extends JarRequestBody, M extends JarMessageParameters>
-            HandlerRequest<REQB, M> createRequest(
+            HandlerRequest<REQB> createRequest(
                     REQB requestBody, M parameters, M unresolvedMessageParameters, Path jar)
                     throws HandlerRequestException {
 
@@ -316,7 +316,7 @@ public abstract class JarHandlerParameterTest<
 
     abstract REQB getJarRequestBodyWithJobId(JobID jobId);
 
-    abstract void handleRequest(HandlerRequest<REQB, M> request) throws Exception;
+    abstract void handleRequest(HandlerRequest<REQB> request) throws Exception;
 
     JobGraph validateDefaultGraph() {
         JobGraph jobGraph = LAST_SUBMITTED_JOB_GRAPH_REFERENCE.getAndSet(null);

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlers.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlers.java
@@ -105,7 +105,8 @@ public class JarHandlers {
 
     public static String uploadJar(
             JarUploadHandler handler, Path jar, RestfulGateway restfulGateway) throws Exception {
-        HandlerRequest<EmptyRequestBody, EmptyMessageParameters> uploadRequest =
+
+        HandlerRequest<EmptyRequestBody> uploadRequest =
                 HandlerRequest.create(
                         EmptyRequestBody.getInstance(),
                         EmptyMessageParameters.getInstance(),
@@ -117,7 +118,7 @@ public class JarHandlers {
 
     public static JarListInfo listJars(JarListHandler handler, RestfulGateway restfulGateway)
             throws Exception {
-        HandlerRequest<EmptyRequestBody, EmptyMessageParameters> listRequest =
+        HandlerRequest<EmptyRequestBody> listRequest =
                 HandlerRequest.create(
                         EmptyRequestBody.getInstance(), EmptyMessageParameters.getInstance());
         return handler.handleRequest(listRequest, restfulGateway).get();
@@ -128,7 +129,7 @@ public class JarHandlers {
             throws Exception {
         JarPlanMessageParameters planParameters =
                 JarPlanGetHeaders.getInstance().getUnresolvedMessageParameters();
-        HandlerRequest<JarPlanRequestBody, JarPlanMessageParameters> planRequest =
+        HandlerRequest<JarPlanRequestBody> planRequest =
                 HandlerRequest.resolveParametersAndCreate(
                         new JarPlanRequestBody(),
                         planParameters,
@@ -144,7 +145,7 @@ public class JarHandlers {
             throws Exception {
         final JarRunMessageParameters runParameters =
                 JarRunHeaders.getInstance().getUnresolvedMessageParameters();
-        HandlerRequest<JarRunRequestBody, JarRunMessageParameters> runRequest =
+        HandlerRequest<JarRunRequestBody> runRequest =
                 HandlerRequest.resolveParametersAndCreate(
                         new JarRunRequestBody(),
                         runParameters,
@@ -160,7 +161,7 @@ public class JarHandlers {
             throws Exception {
         JarDeleteMessageParameters deleteParameters =
                 JarDeleteHeaders.getInstance().getUnresolvedMessageParameters();
-        HandlerRequest<EmptyRequestBody, JarDeleteMessageParameters> deleteRequest =
+        HandlerRequest<EmptyRequestBody> deleteRequest =
                 HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         deleteParameters,

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlers.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlers.java
@@ -106,11 +106,9 @@ public class JarHandlers {
     public static String uploadJar(
             JarUploadHandler handler, Path jar, RestfulGateway restfulGateway) throws Exception {
         HandlerRequest<EmptyRequestBody, EmptyMessageParameters> uploadRequest =
-                new HandlerRequest<>(
+                HandlerRequest.create(
                         EmptyRequestBody.getInstance(),
                         EmptyMessageParameters.getInstance(),
-                        Collections.emptyMap(),
-                        Collections.emptyMap(),
                         Collections.singletonList(jar.toFile()));
         final JarUploadResponseBody uploadResponse =
                 handler.handleRequest(uploadRequest, restfulGateway).get();
@@ -120,7 +118,7 @@ public class JarHandlers {
     public static JarListInfo listJars(JarListHandler handler, RestfulGateway restfulGateway)
             throws Exception {
         HandlerRequest<EmptyRequestBody, EmptyMessageParameters> listRequest =
-                new HandlerRequest<>(
+                HandlerRequest.create(
                         EmptyRequestBody.getInstance(), EmptyMessageParameters.getInstance());
         return handler.handleRequest(listRequest, restfulGateway).get();
     }
@@ -131,7 +129,7 @@ public class JarHandlers {
         JarPlanMessageParameters planParameters =
                 JarPlanGetHeaders.getInstance().getUnresolvedMessageParameters();
         HandlerRequest<JarPlanRequestBody, JarPlanMessageParameters> planRequest =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         new JarPlanRequestBody(),
                         planParameters,
                         Collections.singletonMap(
@@ -147,7 +145,7 @@ public class JarHandlers {
         final JarRunMessageParameters runParameters =
                 JarRunHeaders.getInstance().getUnresolvedMessageParameters();
         HandlerRequest<JarRunRequestBody, JarRunMessageParameters> runRequest =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         new JarRunRequestBody(),
                         runParameters,
                         Collections.singletonMap(
@@ -163,7 +161,7 @@ public class JarHandlers {
         JarDeleteMessageParameters deleteParameters =
                 JarDeleteHeaders.getInstance().getUnresolvedMessageParameters();
         HandlerRequest<EmptyRequestBody, JarDeleteMessageParameters> deleteRequest =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         deleteParameters,
                         Collections.singletonMap(

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHandlerParameterTest.java
@@ -119,8 +119,7 @@ public class JarPlanHandlerParameterTest
     }
 
     @Override
-    void handleRequest(HandlerRequest<JarPlanRequestBody, JarPlanMessageParameters> request)
-            throws Exception {
+    void handleRequest(HandlerRequest<JarPlanRequestBody> request) throws Exception {
         handler.handleRequest(request, restfulGateway).get();
     }
 }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
@@ -192,7 +192,7 @@ public class JarRunHandlerParameterTest
 
     @Test
     public void testRestHandlerExceptionThrownWithEagerSinks() throws Exception {
-        final HandlerRequest<JarRunRequestBody, JarRunMessageParameters> request =
+        final HandlerRequest<JarRunRequestBody> request =
                 createRequest(
                         getDefaultJarRequestBody(),
                         getUnresolvedJarMessageParameters(),
@@ -226,8 +226,7 @@ public class JarRunHandlerParameterTest
     }
 
     @Override
-    void handleRequest(HandlerRequest<JarRunRequestBody, JarRunMessageParameters> request)
-            throws Exception {
+    void handleRequest(HandlerRequest<JarRunRequestBody> request) throws Exception {
         handler.handleRequest(request, restfulGateway).get();
     }
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHandlerTest.java
@@ -138,11 +138,9 @@ public class JarUploadHandlerTest extends TestLogger {
 
     private static HandlerRequest<EmptyRequestBody, EmptyMessageParameters> createRequest(
             final Path uploadedFile) throws HandlerRequestException, IOException {
-        return new HandlerRequest<>(
+        return HandlerRequest.create(
                 EmptyRequestBody.getInstance(),
                 EmptyMessageParameters.getInstance(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
                 Collections.singleton(uploadedFile.toFile()));
     }
 }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHandlerTest.java
@@ -80,8 +80,7 @@ public class JarUploadHandlerTest extends TestLogger {
     @Test
     public void testRejectNonJarFiles() throws Exception {
         final Path uploadedFile = Files.createFile(jarDir.resolve("katrin.png"));
-        final HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request =
-                createRequest(uploadedFile);
+        final HandlerRequest<EmptyRequestBody> request = createRequest(uploadedFile);
 
         try {
             jarUploadHandler.handleRequest(request, mockDispatcherGateway).get();
@@ -99,8 +98,7 @@ public class JarUploadHandlerTest extends TestLogger {
     @Test
     public void testUploadJar() throws Exception {
         final Path uploadedFile = Files.createFile(jarDir.resolve("FooBazzleExample.jar"));
-        final HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request =
-                createRequest(uploadedFile);
+        final HandlerRequest<EmptyRequestBody> request = createRequest(uploadedFile);
 
         final JarUploadResponseBody jarUploadResponseBody =
                 jarUploadHandler.handleRequest(request, mockDispatcherGateway).get();
@@ -117,8 +115,7 @@ public class JarUploadHandlerTest extends TestLogger {
     @Test
     public void testFailedUpload() throws Exception {
         final Path uploadedFile = jarDir.resolve("FooBazzleExample.jar");
-        final HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request =
-                createRequest(uploadedFile);
+        final HandlerRequest<EmptyRequestBody> request = createRequest(uploadedFile);
 
         try {
             jarUploadHandler.handleRequest(request, mockDispatcherGateway).get();
@@ -136,8 +133,8 @@ public class JarUploadHandlerTest extends TestLogger {
         }
     }
 
-    private static HandlerRequest<EmptyRequestBody, EmptyMessageParameters> createRequest(
-            final Path uploadedFile) throws HandlerRequestException, IOException {
+    private static HandlerRequest<EmptyRequestBody> createRequest(final Path uploadedFile)
+            throws HandlerRequestException, IOException {
         return HandlerRequest.create(
                 EmptyRequestBody.getInstance(),
                 EmptyMessageParameters.getInstance(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/FlinkJobTerminatedWithoutCancellationException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/FlinkJobTerminatedWithoutCancellationException.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.messages;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Exception indicating that the Flink job with the given job ID has terminated without
+ * cancellation.
+ */
+public class FlinkJobTerminatedWithoutCancellationException extends FlinkException {
+
+    private static final long serialVersionUID = 2294698055059659025L;
+
+    private final JobStatus jobStatus;
+
+    public FlinkJobTerminatedWithoutCancellationException(JobID jobId, JobStatus jobStatus) {
+        super(
+                String.format(
+                        "Flink job (%s) was not canceled, but instead %s.",
+                        jobId, assertNotCanceled(jobStatus)));
+        this.jobStatus = jobStatus;
+    }
+
+    public JobStatus getJobStatus() {
+        return jobStatus;
+    }
+
+    private static JobStatus assertNotCanceled(JobStatus jobStatus) {
+        Preconditions.checkState(jobStatus != JobStatus.CANCELED);
+        return jobStatus;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
@@ -175,7 +175,7 @@ public abstract class AbstractHandler<
 
             try {
                 handlerRequest =
-                        new HandlerRequest<R, M>(
+                        HandlerRequest.resolveParametersAndCreate(
                                 request,
                                 untypedResponseMessageHeaders.getUnresolvedMessageParameters(),
                                 routedRequest.getRouteResult().pathParams(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
@@ -171,7 +171,7 @@ public abstract class AbstractHandler<
                 }
             }
 
-            final HandlerRequest<R, M> handlerRequest;
+            final HandlerRequest<R> handlerRequest;
 
             try {
                 handlerRequest =
@@ -316,7 +316,7 @@ public abstract class AbstractHandler<
     protected abstract CompletableFuture<Void> respondToRequest(
             ChannelHandlerContext ctx,
             HttpRequest httpRequest,
-            HandlerRequest<R, M> handlerRequest,
+            HandlerRequest<R> handlerRequest,
             T gateway)
             throws RestHandlerException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -75,7 +75,7 @@ public abstract class AbstractRestHandler<
     protected CompletableFuture<Void> respondToRequest(
             ChannelHandlerContext ctx,
             HttpRequest httpRequest,
-            HandlerRequest<R, M> handlerRequest,
+            HandlerRequest<R> handlerRequest,
             T gateway) {
         CompletableFuture<P> response;
 
@@ -113,5 +113,5 @@ public abstract class AbstractRestHandler<
      * @throws RestHandlerException if the handling failed
      */
     protected abstract CompletableFuture<P> handleRequest(
-            @Nonnull HandlerRequest<R, M> request, @Nonnull T gateway) throws RestHandlerException;
+            @Nonnull HandlerRequest<R> request, @Nonnull T gateway) throws RestHandlerException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/HandlerRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/HandlerRequest.java
@@ -41,9 +41,8 @@ import java.util.StringJoiner;
  * path/query parameters.
  *
  * @param <R> type of the contained request body
- * @param <M> type of the contained message parameters
  */
-public class HandlerRequest<R extends RequestBody, M extends MessageParameters> {
+public class HandlerRequest<R extends RequestBody> {
 
     private final R requestBody;
     private final Collection<File> uploadedFiles;
@@ -123,7 +122,7 @@ public class HandlerRequest<R extends RequestBody, M extends MessageParameters> 
      * uploaded files.
      */
     @VisibleForTesting
-    public static <R extends RequestBody, M extends MessageParameters> HandlerRequest<R, M> create(
+    public static <R extends RequestBody, M extends MessageParameters> HandlerRequest<R> create(
             R requestBody, M messageParameters) {
         return create(requestBody, messageParameters, Collections.emptyList());
     }
@@ -133,9 +132,9 @@ public class HandlerRequest<R extends RequestBody, M extends MessageParameters> 
      * resolved.
      */
     @VisibleForTesting
-    public static <R extends RequestBody, M extends MessageParameters> HandlerRequest<R, M> create(
+    public static <R extends RequestBody, M extends MessageParameters> HandlerRequest<R> create(
             R requestBody, M messageParameters, Collection<File> uploadedFiles) {
-        return new HandlerRequest<R, M>(
+        return new HandlerRequest<R>(
                 requestBody,
                 mapParameters(messageParameters.getPathParameters()),
                 mapParameters(messageParameters.getQueryParameters()),
@@ -149,7 +148,7 @@ public class HandlerRequest<R extends RequestBody, M extends MessageParameters> 
      * <p>For tests it is recommended to resolve the parameters manually and use {@link #create}.
      */
     public static <R extends RequestBody, M extends MessageParameters>
-            HandlerRequest<R, M> resolveParametersAndCreate(
+            HandlerRequest<R> resolveParametersAndCreate(
                     R requestBody,
                     M messageParameters,
                     Map<String, String> receivedPathParameters,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/HandlerRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/HandlerRequest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.rest.handler;
 
+import org.apache.flink.runtime.rest.messages.MessageParameter;
 import org.apache.flink.runtime.rest.messages.MessageParameters;
 import org.apache.flink.runtime.rest.messages.MessagePathParameter;
 import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
@@ -46,9 +47,9 @@ public class HandlerRequest<R extends RequestBody, M extends MessageParameters> 
     private final R requestBody;
     private final Collection<File> uploadedFiles;
     private final Map<Class<? extends MessagePathParameter<?>>, MessagePathParameter<?>>
-            pathParameters = new HashMap<>(2);
+            pathParameters;
     private final Map<Class<? extends MessageQueryParameter<?>>, MessageQueryParameter<?>>
-            queryParameters = new HashMap<>(2);
+            queryParameters;
 
     public HandlerRequest(R requestBody, M messageParameters) throws HandlerRequestException {
         this(
@@ -87,50 +88,8 @@ public class HandlerRequest<R extends RequestBody, M extends MessageParameters> 
         Preconditions.checkNotNull(receivedQueryParameters);
         Preconditions.checkNotNull(receivedPathParameters);
 
-        for (MessagePathParameter<?> pathParameter : messageParameters.getPathParameters()) {
-            String value = receivedPathParameters.get(pathParameter.getKey());
-            if (value != null) {
-                try {
-                    pathParameter.resolveFromString(value);
-                } catch (Exception e) {
-                    throw new HandlerRequestException(
-                            "Cannot resolve path parameter ("
-                                    + pathParameter.getKey()
-                                    + ") from value \""
-                                    + value
-                                    + "\".");
-                }
-
-                @SuppressWarnings("unchecked")
-                Class<? extends MessagePathParameter<?>> clazz =
-                        (Class<? extends MessagePathParameter<?>>) pathParameter.getClass();
-                pathParameters.put(clazz, pathParameter);
-            }
-        }
-
-        for (MessageQueryParameter<?> queryParameter : messageParameters.getQueryParameters()) {
-            List<String> values = receivedQueryParameters.get(queryParameter.getKey());
-            if (values != null && !values.isEmpty()) {
-                StringJoiner joiner = new StringJoiner(",");
-                values.forEach(joiner::add);
-
-                try {
-                    queryParameter.resolveFromString(joiner.toString());
-                } catch (Exception e) {
-                    throw new HandlerRequestException(
-                            "Cannot resolve query parameter ("
-                                    + queryParameter.getKey()
-                                    + ") from value \""
-                                    + joiner
-                                    + "\".");
-                }
-
-                @SuppressWarnings("unchecked")
-                Class<? extends MessageQueryParameter<?>> clazz =
-                        (Class<? extends MessageQueryParameter<?>>) queryParameter.getClass();
-                queryParameters.put(clazz, queryParameter);
-            }
-        }
+        pathParameters = resolvePathParameters(messageParameters, receivedPathParameters);
+        queryParameters = resolveQueryParameters(messageParameters, receivedQueryParameters);
     }
 
     /**
@@ -182,5 +141,72 @@ public class HandlerRequest<R extends RequestBody, M extends MessageParameters> 
     @Nonnull
     public Collection<File> getUploadedFiles() {
         return uploadedFiles;
+    }
+
+    private static Map<Class<? extends MessagePathParameter<?>>, MessagePathParameter<?>>
+            resolvePathParameters(
+                    MessageParameters messageParameters, Map<String, String> receivedPathParameters)
+                    throws HandlerRequestException {
+
+        for (MessagePathParameter<?> pathParameter : messageParameters.getPathParameters()) {
+            String value = receivedPathParameters.get(pathParameter.getKey());
+            if (value != null) {
+                try {
+                    pathParameter.resolveFromString(value);
+                } catch (Exception e) {
+                    throw new HandlerRequestException(
+                            "Cannot resolve path parameter ("
+                                    + pathParameter.getKey()
+                                    + ") from value \""
+                                    + value
+                                    + "\".");
+                }
+            }
+        }
+
+        return mapParameters(messageParameters.getPathParameters());
+    }
+
+    private static Map<Class<? extends MessageQueryParameter<?>>, MessageQueryParameter<?>>
+            resolveQueryParameters(
+                    MessageParameters messageParameters,
+                    Map<String, List<String>> receivedQueryParameters)
+                    throws HandlerRequestException {
+
+        for (MessageQueryParameter<?> queryParameter : messageParameters.getQueryParameters()) {
+            List<String> values = receivedQueryParameters.get(queryParameter.getKey());
+            if (values != null && !values.isEmpty()) {
+                StringJoiner joiner = new StringJoiner(",");
+                values.forEach(joiner::add);
+
+                try {
+                    queryParameter.resolveFromString(joiner.toString());
+                } catch (Exception e) {
+                    throw new HandlerRequestException(
+                            "Cannot resolve query parameter ("
+                                    + queryParameter.getKey()
+                                    + ") from value \""
+                                    + joiner
+                                    + "\".");
+                }
+            }
+        }
+
+        return mapParameters(messageParameters.getQueryParameters());
+    }
+
+    private static <P extends MessageParameter<?>> Map<Class<? extends P>, P> mapParameters(
+            Collection<P> pathParameters) {
+        final Map<Class<? extends P>, P> mappedParameters = new HashMap<>(2);
+
+        for (P pathParameter : pathParameters) {
+            if (pathParameter.isResolved()) {
+                @SuppressWarnings("unchecked")
+                Class<P> clazz = (Class<P>) pathParameter.getClass();
+                mappedParameters.put(clazz, pathParameter);
+            }
+        }
+
+        return mappedParameters;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlers.java
@@ -113,7 +113,7 @@ public abstract class AbstractAsynchronousOperationHandlers<K extends OperationK
 
         @Override
         public CompletableFuture<TriggerResponse> handleRequest(
-                @Nonnull HandlerRequest<B, M> request, @Nonnull T gateway)
+                @Nonnull HandlerRequest<B> request, @Nonnull T gateway)
                 throws RestHandlerException {
             final CompletableFuture<R> resultFuture = triggerOperation(request, gateway);
 
@@ -134,7 +134,7 @@ public abstract class AbstractAsynchronousOperationHandlers<K extends OperationK
          * @throws RestHandlerException if something went wrong
          */
         protected abstract CompletableFuture<R> triggerOperation(
-                HandlerRequest<B, M> request, T gateway) throws RestHandlerException;
+                HandlerRequest<B> request, T gateway) throws RestHandlerException;
 
         /**
          * Create the operation key under which the result future of the asynchronous operation will
@@ -143,7 +143,7 @@ public abstract class AbstractAsynchronousOperationHandlers<K extends OperationK
          * @param request with which the trigger handler has been called.
          * @return Operation key under which the result future will be stored
          */
-        protected abstract K createOperationKey(HandlerRequest<B, M> request);
+        protected abstract K createOperationKey(HandlerRequest<B> request);
     }
 
     /**
@@ -170,7 +170,7 @@ public abstract class AbstractAsynchronousOperationHandlers<K extends OperationK
 
         @Override
         public CompletableFuture<AsynchronousOperationResult<V>> handleRequest(
-                @Nonnull HandlerRequest<EmptyRequestBody, M> request, @Nonnull T gateway)
+                @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull T gateway)
                 throws RestHandlerException {
 
             final K key = getOperationKey(request);
@@ -210,7 +210,7 @@ public abstract class AbstractAsynchronousOperationHandlers<K extends OperationK
          * @param request with which the status handler has been called
          * @return Operation key under which the operation result future is stored
          */
-        protected abstract K getOperationKey(HandlerRequest<EmptyRequestBody, M> request);
+        protected abstract K getOperationKey(HandlerRequest<EmptyRequestBody> request);
 
         /**
          * Create an exceptional operation result from the given {@link Throwable}. This method is

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/AbstractJobManagerFileHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/AbstractJobManagerFileHandler.java
@@ -58,7 +58,7 @@ public abstract class AbstractJobManagerFileHandler<M extends MessageParameters>
     protected CompletableFuture<Void> respondToRequest(
             ChannelHandlerContext ctx,
             HttpRequest httpRequest,
-            HandlerRequest<EmptyRequestBody, M> handlerRequest,
+            HandlerRequest<EmptyRequestBody> handlerRequest,
             RestfulGateway gateway) {
         File file = getFile(handlerRequest);
         if (file != null && file.exists()) {
@@ -80,5 +80,5 @@ public abstract class AbstractJobManagerFileHandler<M extends MessageParameters>
     }
 
     @Nullable
-    protected abstract File getFile(HandlerRequest<EmptyRequestBody, M> handlerRequest);
+    protected abstract File getFile(HandlerRequest<EmptyRequestBody> handlerRequest);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/ClusterConfigHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/ClusterConfigHandler.java
@@ -61,8 +61,7 @@ public class ClusterConfigHandler
 
     @Override
     protected CompletableFuture<ClusterConfigurationInfo> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
-            @Nonnull RestfulGateway gateway)
+            @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
             throws RestHandlerException {
         return CompletableFuture.completedFuture(clusterConfig);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/ClusterOverviewHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/ClusterOverviewHandler.java
@@ -58,8 +58,7 @@ public class ClusterOverviewHandler
 
     @Override
     public CompletableFuture<ClusterOverviewWithVersion> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
-            @Nonnull RestfulGateway gateway) {
+            @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway) {
         CompletableFuture<ClusterOverview> overviewFuture = gateway.requestClusterOverview(timeout);
 
         return overviewFuture.thenApply(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/DashboardConfigHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/DashboardConfigHandler.java
@@ -59,8 +59,7 @@ public class DashboardConfigHandler
 
     @Override
     public CompletableFuture<DashboardConfiguration> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
-            @Nonnull RestfulGateway gateway) {
+            @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway) {
         return CompletableFuture.completedFuture(dashboardConfiguration);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerCustomLogHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerCustomLogHandler.java
@@ -50,7 +50,7 @@ public class JobManagerCustomLogHandler
     }
 
     @Override
-    protected File getFile(HandlerRequest<EmptyRequestBody, FileMessageParameters> handlerRequest) {
+    protected File getFile(HandlerRequest<EmptyRequestBody> handlerRequest) {
         if (logDir == null) {
             return null;
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerLogFileHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerLogFileHandler.java
@@ -49,8 +49,7 @@ public class JobManagerLogFileHandler
     }
 
     @Override
-    protected File getFile(
-            HandlerRequest<EmptyRequestBody, EmptyMessageParameters> handlerRequest) {
+    protected File getFile(HandlerRequest<EmptyRequestBody> handlerRequest) {
         return file;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerLogListHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerLogListHandler.java
@@ -63,8 +63,7 @@ public class JobManagerLogListHandler
 
     @Override
     protected CompletableFuture<LogListInfo> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
-            @Nonnull RestfulGateway gateway)
+            @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
             throws RestHandlerException {
         if (logDir == null) {
             return CompletableFuture.completedFuture(new LogListInfo(Collections.emptyList()));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/ShutdownHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/ShutdownHandler.java
@@ -50,7 +50,7 @@ public class ShutdownHandler
 
     @Override
     protected CompletableFuture<EmptyResponseBody> handleRequest(
-            @Nonnull final HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
+            @Nonnull final HandlerRequest<EmptyRequestBody> request,
             @Nonnull final RestfulGateway gateway)
             throws RestHandlerException {
         return gateway.shutDownCluster().thenApply(ignored -> EmptyResponseBody.getInstance());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/dataset/ClusterDataSetDeleteHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/dataset/ClusterDataSetDeleteHandlers.java
@@ -69,9 +69,7 @@ public class ClusterDataSetDeleteHandlers
 
         @Override
         protected CompletableFuture<Void> triggerOperation(
-                HandlerRequest<EmptyRequestBody, ClusterDataSetDeleteTriggerMessageParameters>
-                        request,
-                RestfulGateway gateway)
+                HandlerRequest<EmptyRequestBody> request, RestfulGateway gateway)
                 throws RestHandlerException {
             final IntermediateDataSetID clusterPartitionId =
                     request.getPathParameter(ClusterDataSetIdPathParameter.class);
@@ -82,9 +80,7 @@ public class ClusterDataSetDeleteHandlers
         }
 
         @Override
-        protected OperationKey createOperationKey(
-                HandlerRequest<EmptyRequestBody, ClusterDataSetDeleteTriggerMessageParameters>
-                        request) {
+        protected OperationKey createOperationKey(HandlerRequest<EmptyRequestBody> request) {
             return new OperationKey(new TriggerId());
         }
     }
@@ -108,9 +104,7 @@ public class ClusterDataSetDeleteHandlers
         }
 
         @Override
-        protected OperationKey getOperationKey(
-                HandlerRequest<EmptyRequestBody, ClusterDataSetDeleteStatusMessageParameters>
-                        request) {
+        protected OperationKey getOperationKey(HandlerRequest<EmptyRequestBody> request) {
             final TriggerId triggerId = request.getPathParameter(TriggerIdPathParameter.class);
             return new OperationKey(triggerId);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/dataset/ClusterDataSetListHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/dataset/ClusterDataSetListHandler.java
@@ -56,7 +56,7 @@ public class ClusterDataSetListHandler
 
     @Override
     protected CompletableFuture<ClusterDataSetListResponseBody> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
+            @Nonnull HandlerRequest<EmptyRequestBody> request,
             @Nonnull ResourceManagerGateway gateway)
             throws RestHandlerException {
         return gateway.listDataSets().thenApply(ClusterDataSetListResponseBody::from);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AbstractAccessExecutionGraphHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AbstractAccessExecutionGraphHandler.java
@@ -63,12 +63,12 @@ public abstract class AbstractAccessExecutionGraphHandler<
 
     @Override
     protected R handleRequest(
-            HandlerRequest<EmptyRequestBody, M> request, ExecutionGraphInfo executionGraphInfo)
+            HandlerRequest<EmptyRequestBody> request, ExecutionGraphInfo executionGraphInfo)
             throws RestHandlerException {
         return handleRequest(request, executionGraphInfo.getArchivedExecutionGraph());
     }
 
     protected abstract R handleRequest(
-            HandlerRequest<EmptyRequestBody, M> request, AccessExecutionGraph executionGraph)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionGraph executionGraph)
             throws RestHandlerException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AbstractExecutionGraphHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AbstractExecutionGraphHandler.java
@@ -73,7 +73,7 @@ public abstract class AbstractExecutionGraphHandler<
 
     @Override
     protected CompletableFuture<R> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, M> request, @Nonnull RestfulGateway gateway)
+            @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
             throws RestHandlerException {
         JobID jobId = request.getPathParameter(JobIDPathParameter.class);
 
@@ -114,6 +114,6 @@ public abstract class AbstractExecutionGraphHandler<
      * @throws RestHandlerException if the handler could not process the request
      */
     protected abstract R handleRequest(
-            HandlerRequest<EmptyRequestBody, M> request, ExecutionGraphInfo executionGraphInfo)
+            HandlerRequest<EmptyRequestBody> request, ExecutionGraphInfo executionGraphInfo)
             throws RestHandlerException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AbstractJobVertexHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AbstractJobVertexHandler.java
@@ -80,7 +80,7 @@ public abstract class AbstractJobVertexHandler<
 
     @Override
     protected R handleRequest(
-            HandlerRequest<EmptyRequestBody, M> request, AccessExecutionGraph executionGraph)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionGraph executionGraph)
             throws RestHandlerException {
 
         final JobVertexID jobVertexID = request.getPathParameter(JobVertexIdPathParameter.class);
@@ -105,6 +105,6 @@ public abstract class AbstractJobVertexHandler<
      * @throws RestHandlerException if the handler could not process the request
      */
     protected abstract R handleRequest(
-            HandlerRequest<EmptyRequestBody, M> request, AccessExecutionJobVertex jobVertex)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionJobVertex jobVertex)
             throws RestHandlerException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AbstractSubtaskAttemptHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AbstractSubtaskAttemptHandler.java
@@ -82,7 +82,7 @@ public abstract class AbstractSubtaskAttemptHandler<
 
     @Override
     protected R handleRequest(
-            HandlerRequest<EmptyRequestBody, M> request, AccessExecutionVertex executionVertex)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionVertex executionVertex)
             throws RestHandlerException {
         final Integer attemptNumber = request.getPathParameter(SubtaskAttemptPathParameter.class);
 
@@ -119,6 +119,6 @@ public abstract class AbstractSubtaskAttemptHandler<
      * @throws RestHandlerException the rest handler exception
      */
     protected abstract R handleRequest(
-            HandlerRequest<EmptyRequestBody, M> request, AccessExecution execution)
+            HandlerRequest<EmptyRequestBody> request, AccessExecution execution)
             throws RestHandlerException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AbstractSubtaskHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AbstractSubtaskHandler.java
@@ -81,7 +81,7 @@ public abstract class AbstractSubtaskHandler<
 
     @Override
     protected R handleRequest(
-            HandlerRequest<EmptyRequestBody, M> request, AccessExecutionJobVertex jobVertex)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionJobVertex jobVertex)
             throws RestHandlerException {
 
         final Integer subtaskIndex = request.getPathParameter(SubtaskIndexPathParameter.class);
@@ -106,6 +106,6 @@ public abstract class AbstractSubtaskHandler<
      * @throws RestHandlerException the rest handler exception
      */
     protected abstract R handleRequest(
-            HandlerRequest<EmptyRequestBody, M> request, AccessExecutionVertex executionVertex)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionVertex executionVertex)
             throws RestHandlerException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobAccumulatorsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobAccumulatorsHandler.java
@@ -71,8 +71,7 @@ public class JobAccumulatorsHandler
 
     @Override
     protected JobAccumulatorsInfo handleRequest(
-            HandlerRequest<EmptyRequestBody, JobAccumulatorsMessageParameters> request,
-            AccessExecutionGraph graph)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionGraph graph)
             throws RestHandlerException {
         List<Boolean> queryParams =
                 request.getQueryParameter(AccumulatorsIncludeSerializedValueQueryParameter.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobCancellationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobCancellationHandler.java
@@ -69,8 +69,7 @@ public class JobCancellationHandler
 
     @Override
     public CompletableFuture<EmptyResponseBody> handleRequest(
-            HandlerRequest<EmptyRequestBody, JobCancellationMessageParameters> request,
-            RestfulGateway gateway)
+            HandlerRequest<EmptyRequestBody> request, RestfulGateway gateway)
             throws RestHandlerException {
         final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
         final List<TerminationModeQueryParameter.TerminationMode> terminationModes =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobConfigHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobConfigHandler.java
@@ -64,8 +64,7 @@ public class JobConfigHandler
 
     @Override
     protected JobConfigInfo handleRequest(
-            HandlerRequest<EmptyRequestBody, JobMessageParameters> request,
-            AccessExecutionGraph executionGraph) {
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionGraph executionGraph) {
         return createJobConfigInfo(executionGraph);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
@@ -82,8 +82,7 @@ public class JobDetailsHandler
 
     @Override
     protected JobDetailsInfo handleRequest(
-            HandlerRequest<EmptyRequestBody, JobMessageParameters> request,
-            AccessExecutionGraph executionGraph)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionGraph executionGraph)
             throws RestHandlerException {
         return createJobDetailsInfo(executionGraph, metricFetcher);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
@@ -90,8 +90,7 @@ public class JobExceptionsHandler
 
     @Override
     protected JobExceptionsInfoWithHistory handleRequest(
-            HandlerRequest<EmptyRequestBody, JobExceptionsMessageParameters> request,
-            ExecutionGraphInfo executionGraph) {
+            HandlerRequest<EmptyRequestBody> request, ExecutionGraphInfo executionGraph) {
         List<Integer> exceptionToReportMaxSizes =
                 request.getQueryParameter(UpperLimitExceptionParameter.class);
         final int exceptionToReportMaxSize =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExecutionResultHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExecutionResultHandler.java
@@ -59,7 +59,7 @@ public class JobExecutionResultHandler
 
     @Override
     protected CompletableFuture<JobExecutionResultResponseBody> handleRequest(
-            @Nonnull final HandlerRequest<EmptyRequestBody, JobMessageParameters> request,
+            @Nonnull final HandlerRequest<EmptyRequestBody> request,
             @Nonnull final RestfulGateway gateway)
             throws RestHandlerException {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobIdsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobIdsHandler.java
@@ -54,8 +54,7 @@ public class JobIdsHandler
 
     @Override
     protected CompletableFuture<JobIdsWithStatusOverview> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
-            @Nonnull RestfulGateway gateway)
+            @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
             throws RestHandlerException {
 
         return gateway.requestMultipleJobDetails(timeout)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobPlanHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobPlanHandler.java
@@ -57,8 +57,7 @@ public class JobPlanHandler
 
     @Override
     protected JobPlanInfo handleRequest(
-            HandlerRequest<EmptyRequestBody, JobMessageParameters> request,
-            AccessExecutionGraph executionGraph)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionGraph executionGraph)
             throws RestHandlerException {
         return createJobPlanInfo(executionGraph);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
@@ -80,7 +80,7 @@ public final class JobSubmitHandler
 
     @Override
     protected CompletableFuture<JobSubmitResponseBody> handleRequest(
-            @Nonnull HandlerRequest<JobSubmitRequestBody, EmptyMessageParameters> request,
+            @Nonnull HandlerRequest<JobSubmitRequestBody> request,
             @Nonnull DispatcherGateway gateway)
             throws RestHandlerException {
         final Collection<File> uploadedFiles = request.getUploadedFiles();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexAccumulatorsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexAccumulatorsHandler.java
@@ -59,8 +59,7 @@ public class JobVertexAccumulatorsHandler
 
     @Override
     protected JobVertexAccumulatorsInfo handleRequest(
-            HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request,
-            AccessExecutionJobVertex jobVertex)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionJobVertex jobVertex)
             throws RestHandlerException {
 
         StringifiedAccumulatorResult[] accs = jobVertex.getAggregatedUserAccumulatorsStringified();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandler.java
@@ -69,8 +69,7 @@ public class JobVertexBackPressureHandler
 
     @Override
     protected CompletableFuture<JobVertexBackPressureInfo> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request,
-            @Nonnull RestfulGateway gateway)
+            @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
             throws RestHandlerException {
         metricFetcher.update();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexDetailsHandler.java
@@ -79,8 +79,7 @@ public class JobVertexDetailsHandler
 
     @Override
     protected JobVertexDetailsInfo handleRequest(
-            HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request,
-            AccessExecutionGraph executionGraph)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionGraph executionGraph)
             throws NotFoundException {
         JobID jobID = request.getPathParameter(JobIDPathParameter.class);
         JobVertexID jobVertexID = request.getPathParameter(JobVertexIdPathParameter.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexFlameGraphHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexFlameGraphHandler.java
@@ -71,8 +71,7 @@ public class JobVertexFlameGraphHandler
 
     @Override
     protected JobVertexFlameGraph handleRequest(
-            HandlerRequest<EmptyRequestBody, JobVertexFlameGraphParameters> request,
-            AccessExecutionJobVertex jobVertex)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionJobVertex jobVertex)
             throws RestHandlerException {
 
         if (jobVertex.getAggregateState().isTerminal()) {
@@ -109,8 +108,7 @@ public class JobVertexFlameGraphHandler
         return operatorFlameGraph.orElse(JobVertexFlameGraph.waiting());
     }
 
-    private static FlameGraphTypeQueryParameter.Type getFlameGraphType(
-            HandlerRequest<?, JobVertexFlameGraphParameters> request) {
+    private static FlameGraphTypeQueryParameter.Type getFlameGraphType(HandlerRequest<?> request) {
         final List<FlameGraphTypeQueryParameter.Type> flameGraphTypeParameter =
                 request.getQueryParameter(FlameGraphTypeQueryParameter.class);
 
@@ -152,8 +150,7 @@ public class JobVertexFlameGraphHandler
 
         @Override
         protected CompletableFuture<JobVertexFlameGraph> handleRequest(
-                @Nonnull HandlerRequest<EmptyRequestBody, JobVertexFlameGraphParameters> request,
-                @Nonnull RestfulGateway gateway)
+                @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
                 throws RestHandlerException {
             return CompletableFuture.completedFuture(JobVertexFlameGraph.disabled());
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexTaskManagersHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexTaskManagersHandler.java
@@ -88,8 +88,7 @@ public class JobVertexTaskManagersHandler
 
     @Override
     protected JobVertexTaskManagersInfo handleRequest(
-            HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request,
-            AccessExecutionGraph executionGraph)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionGraph executionGraph)
             throws RestHandlerException {
         JobID jobID = request.getPathParameter(JobIDPathParameter.class);
         JobVertexID jobVertexID = request.getPathParameter(JobVertexIdPathParameter.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobsOverviewHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobsOverviewHandler.java
@@ -60,8 +60,7 @@ public class JobsOverviewHandler
 
     @Override
     protected CompletableFuture<MultipleJobsDetails> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
-            @Nonnull RestfulGateway gateway)
+            @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
             throws RestHandlerException {
         return gateway.requestMultipleJobDetails(timeout);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandler.java
@@ -73,8 +73,7 @@ public class SubtaskCurrentAttemptDetailsHandler
 
     @Override
     protected SubtaskExecutionAttemptDetailsInfo handleRequest(
-            HandlerRequest<EmptyRequestBody, SubtaskMessageParameters> request,
-            AccessExecutionVertex executionVertex)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionVertex executionVertex)
             throws RestHandlerException {
 
         final AccessExecution execution = executionVertex.getCurrentExecutionAttempt();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandler.java
@@ -88,8 +88,7 @@ public class SubtaskExecutionAttemptAccumulatorsHandler
 
     @Override
     protected SubtaskExecutionAttemptAccumulatorsInfo handleRequest(
-            HandlerRequest<EmptyRequestBody, SubtaskAttemptMessageParameters> request,
-            AccessExecution execution)
+            HandlerRequest<EmptyRequestBody> request, AccessExecution execution)
             throws RestHandlerException {
         return createAccumulatorInfo(execution);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandler.java
@@ -95,8 +95,7 @@ public class SubtaskExecutionAttemptDetailsHandler
 
     @Override
     protected SubtaskExecutionAttemptDetailsInfo handleRequest(
-            HandlerRequest<EmptyRequestBody, SubtaskAttemptMessageParameters> request,
-            AccessExecution execution)
+            HandlerRequest<EmptyRequestBody> request, AccessExecution execution)
             throws RestHandlerException {
 
         final JobID jobID = request.getPathParameter(JobIDPathParameter.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtasksAllAccumulatorsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtasksAllAccumulatorsHandler.java
@@ -66,8 +66,7 @@ public class SubtasksAllAccumulatorsHandler
 
     @Override
     protected SubtasksAllAccumulatorsInfo handleRequest(
-            HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request,
-            AccessExecutionJobVertex jobVertex)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionJobVertex jobVertex)
             throws RestHandlerException {
         JobVertexID jobVertexId = jobVertex.getJobVertexId();
         int parallelism = jobVertex.getParallelism();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtasksTimesHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtasksTimesHandler.java
@@ -69,8 +69,7 @@ public class SubtasksTimesHandler
 
     @Override
     protected SubtasksTimesInfo handleRequest(
-            HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request,
-            AccessExecutionJobVertex jobVertex) {
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionJobVertex jobVertex) {
         return createSubtaskTimesInfo(jobVertex);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/AbstractCheckpointHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/AbstractCheckpointHandler.java
@@ -72,7 +72,7 @@ public abstract class AbstractCheckpointHandler<
 
     @Override
     protected R handleRequest(
-            HandlerRequest<EmptyRequestBody, M> request, AccessExecutionGraph executionGraph)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionGraph executionGraph)
             throws RestHandlerException {
         final long checkpointId = request.getPathParameter(CheckpointIdPathParameter.class);
 
@@ -114,6 +114,6 @@ public abstract class AbstractCheckpointHandler<
      * @throws RestHandlerException if the handler could not handle the request
      */
     protected abstract R handleCheckpointRequest(
-            HandlerRequest<EmptyRequestBody, M> request, AbstractCheckpointStats checkpointStats)
+            HandlerRequest<EmptyRequestBody> request, AbstractCheckpointStats checkpointStats)
             throws RestHandlerException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointConfigHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointConfigHandler.java
@@ -71,8 +71,7 @@ public class CheckpointConfigHandler
 
     @Override
     protected CheckpointConfigInfo handleRequest(
-            HandlerRequest<EmptyRequestBody, JobMessageParameters> request,
-            AccessExecutionGraph executionGraph)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionGraph executionGraph)
             throws RestHandlerException {
         return createCheckpointConfigInfo(executionGraph);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointStatisticDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointStatisticDetailsHandler.java
@@ -71,8 +71,7 @@ public class CheckpointStatisticDetailsHandler
 
     @Override
     protected CheckpointStatistics handleCheckpointRequest(
-            HandlerRequest<EmptyRequestBody, CheckpointMessageParameters> ignored,
-            AbstractCheckpointStats checkpointStats) {
+            HandlerRequest<EmptyRequestBody> ignored, AbstractCheckpointStats checkpointStats) {
         return CheckpointStatistics.generateCheckpointStatistics(checkpointStats, true);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointingStatisticsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointingStatisticsHandler.java
@@ -78,8 +78,7 @@ public class CheckpointingStatisticsHandler
 
     @Override
     protected CheckpointingStatistics handleRequest(
-            HandlerRequest<EmptyRequestBody, JobMessageParameters> request,
-            AccessExecutionGraph executionGraph)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionGraph executionGraph)
             throws RestHandlerException {
         return createCheckpointingStatistics(executionGraph);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
@@ -84,8 +84,7 @@ public class TaskCheckpointStatisticDetailsHandler
 
     @Override
     protected TaskCheckpointStatisticsWithSubtaskDetails handleCheckpointRequest(
-            HandlerRequest<EmptyRequestBody, TaskCheckpointMessageParameters> request,
-            AbstractCheckpointStats checkpointStats)
+            HandlerRequest<EmptyRequestBody> request, AbstractCheckpointStats checkpointStats)
             throws RestHandlerException {
 
         final JobVertexID jobVertexId = request.getPathParameter(JobVertexIdPathParameter.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/coordination/ClientCoordinationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/coordination/ClientCoordinationHandler.java
@@ -70,11 +70,7 @@ public class ClientCoordinationHandler
 
     @Override
     protected CompletableFuture<ClientCoordinationResponseBody> handleRequest(
-            @Nonnull
-                    HandlerRequest<
-                                    ClientCoordinationRequestBody,
-                                    ClientCoordinationMessageParameters>
-                            request,
+            @Nonnull HandlerRequest<ClientCoordinationRequestBody> request,
             @Nonnull RestfulGateway gateway)
             throws RestHandlerException {
         JobID jobId = request.getPathParameter(JobIDPathParameter.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractAggregatingMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractAggregatingMetricsHandler.java
@@ -93,11 +93,11 @@ public abstract class AbstractAggregatingMetricsHandler<
 
     @Nonnull
     abstract Collection<? extends MetricStore.ComponentMetricStore> getStores(
-            MetricStore store, HandlerRequest<EmptyRequestBody, P> request);
+            MetricStore store, HandlerRequest<EmptyRequestBody> request);
 
     @Override
     protected CompletableFuture<AggregatedMetricsResponseBody> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, P> request, @Nonnull RestfulGateway gateway)
+            @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
             throws RestHandlerException {
         return CompletableFuture.supplyAsync(
                 () -> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractMetricsHandler.java
@@ -79,7 +79,7 @@ public abstract class AbstractMetricsHandler<M extends MessageParameters>
 
     @Override
     protected final CompletableFuture<MetricCollectionResponseBody> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, M> request, @Nonnull RestfulGateway gateway)
+            @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
             throws RestHandlerException {
         metricFetcher.update();
 
@@ -107,7 +107,7 @@ public abstract class AbstractMetricsHandler<M extends MessageParameters>
     /** Returns the {@link MetricStore.ComponentMetricStore} that should be queried for metrics. */
     @Nullable
     protected abstract MetricStore.ComponentMetricStore getComponentMetricStore(
-            HandlerRequest<EmptyRequestBody, M> request, MetricStore metricStore);
+            HandlerRequest<EmptyRequestBody> request, MetricStore metricStore);
 
     private static List<Metric> getAvailableMetrics(
             MetricStore.ComponentMetricStore componentMetricStore) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/AggregatingJobsMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/AggregatingJobsMetricsHandler.java
@@ -66,8 +66,7 @@ public class AggregatingJobsMetricsHandler
     @Nonnull
     @Override
     Collection<? extends MetricStore.ComponentMetricStore> getStores(
-            MetricStore store,
-            HandlerRequest<EmptyRequestBody, AggregatedJobMetricsParameters> request) {
+            MetricStore store, HandlerRequest<EmptyRequestBody> request) {
         List<JobID> jobs = request.getQueryParameter(JobsFilterQueryParameter.class);
         if (jobs.isEmpty()) {
             return store.getJobs().values();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/AggregatingSubtasksMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/AggregatingSubtasksMetricsHandler.java
@@ -72,8 +72,7 @@ public class AggregatingSubtasksMetricsHandler
     @Nonnull
     @Override
     Collection<? extends MetricStore.ComponentMetricStore> getStores(
-            MetricStore store,
-            HandlerRequest<EmptyRequestBody, AggregatedSubtaskMetricsParameters> request) {
+            MetricStore store, HandlerRequest<EmptyRequestBody> request) {
         JobID jobID = request.getPathParameter(JobIDPathParameter.class);
         JobVertexID taskID = request.getPathParameter(JobVertexIdPathParameter.class);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/AggregatingTaskManagersMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/AggregatingTaskManagersMetricsHandler.java
@@ -66,8 +66,7 @@ public class AggregatingTaskManagersMetricsHandler
     @Nonnull
     @Override
     Collection<? extends MetricStore.ComponentMetricStore> getStores(
-            MetricStore store,
-            HandlerRequest<EmptyRequestBody, AggregateTaskManagerMetricsParameters> request) {
+            MetricStore store, HandlerRequest<EmptyRequestBody> request) {
         List<ResourceID> taskmanagers =
                 request.getQueryParameter(TaskManagersFilterQueryParameter.class);
         if (taskmanagers.isEmpty()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/JobManagerMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/JobManagerMetricsHandler.java
@@ -52,8 +52,7 @@ public class JobManagerMetricsHandler
     @Nullable
     @Override
     protected MetricStore.ComponentMetricStore getComponentMetricStore(
-            final HandlerRequest<EmptyRequestBody, JobManagerMetricsMessageParameters> request,
-            final MetricStore metricStore) {
+            final HandlerRequest<EmptyRequestBody> request, final MetricStore metricStore) {
         return metricStore.getJobManagerMetricStore();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/JobMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/JobMetricsHandler.java
@@ -50,8 +50,7 @@ public class JobMetricsHandler extends AbstractMetricsHandler<JobMetricsMessageP
     @Nullable
     @Override
     protected MetricStore.ComponentMetricStore getComponentMetricStore(
-            final HandlerRequest<EmptyRequestBody, JobMetricsMessageParameters> request,
-            final MetricStore metricStore) {
+            final HandlerRequest<EmptyRequestBody> request, final MetricStore metricStore) {
         return metricStore.getJobMetricStore(
                 request.getPathParameter(JobIDPathParameter.class).toString());
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/JobVertexMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/JobVertexMetricsHandler.java
@@ -60,8 +60,7 @@ public class JobVertexMetricsHandler
 
     @Override
     protected MetricStore.ComponentMetricStore getComponentMetricStore(
-            HandlerRequest<EmptyRequestBody, JobVertexMetricsMessageParameters> request,
-            MetricStore metricStore) {
+            HandlerRequest<EmptyRequestBody> request, MetricStore metricStore) {
 
         final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
         final JobVertexID vertexId = request.getPathParameter(JobVertexIdPathParameter.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/JobVertexWatermarksHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/JobVertexWatermarksHandler.java
@@ -70,8 +70,7 @@ public class JobVertexWatermarksHandler
 
     @Override
     protected MetricCollectionResponseBody handleRequest(
-            HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request,
-            AccessExecutionJobVertex jobVertex)
+            HandlerRequest<EmptyRequestBody> request, AccessExecutionJobVertex jobVertex)
             throws RestHandlerException {
 
         String jobID = request.getPathParameter(JobIDPathParameter.class).toString();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/SubtaskMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/SubtaskMetricsHandler.java
@@ -61,8 +61,7 @@ public class SubtaskMetricsHandler extends AbstractMetricsHandler<SubtaskMetrics
     @Nullable
     @Override
     protected MetricStore.ComponentMetricStore getComponentMetricStore(
-            HandlerRequest<EmptyRequestBody, SubtaskMetricsMessageParameters> request,
-            MetricStore metricStore) {
+            HandlerRequest<EmptyRequestBody> request, MetricStore metricStore) {
 
         final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
         final JobVertexID vertexId = request.getPathParameter(JobVertexIdPathParameter.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/TaskManagerMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/TaskManagerMetricsHandler.java
@@ -58,8 +58,7 @@ public class TaskManagerMetricsHandler
     @Nullable
     @Override
     protected MetricStore.ComponentMetricStore getComponentMetricStore(
-            final HandlerRequest<EmptyRequestBody, TaskManagerMetricsMessageParameters> request,
-            final MetricStore metricStore) {
+            final HandlerRequest<EmptyRequestBody> request, final MetricStore metricStore) {
         final ResourceID taskManagerId = request.getPathParameter(TaskManagerIdPathParameter.class);
         return metricStore.getTaskManagerMetricStore(taskManagerId.toString());
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingHandlers.java
@@ -62,9 +62,7 @@ public class RescalingHandlers
 
         @Override
         public CompletableFuture<TriggerResponse> handleRequest(
-                @Nonnull
-                        final HandlerRequest<EmptyRequestBody, RescalingTriggerMessageParameters>
-                                request,
+                @Nonnull final HandlerRequest<EmptyRequestBody> request,
                 @Nonnull final RestfulGateway gateway)
                 throws RestHandlerException {
             throw featureDisabledException();
@@ -72,14 +70,13 @@ public class RescalingHandlers
 
         @Override
         protected CompletableFuture<Acknowledge> triggerOperation(
-                HandlerRequest<EmptyRequestBody, RescalingTriggerMessageParameters> request,
-                RestfulGateway gateway) {
+                HandlerRequest<EmptyRequestBody> request, RestfulGateway gateway) {
             throw new UnsupportedOperationException();
         }
 
         @Override
         protected AsynchronousJobOperationKey createOperationKey(
-                HandlerRequest<EmptyRequestBody, RescalingTriggerMessageParameters> request) {
+                HandlerRequest<EmptyRequestBody> request) {
             throw new UnsupportedOperationException();
         }
     }
@@ -99,10 +96,7 @@ public class RescalingHandlers
         @Override
         public CompletableFuture<AsynchronousOperationResult<AsynchronousOperationInfo>>
                 handleRequest(
-                        @Nonnull
-                                final HandlerRequest<
-                                                EmptyRequestBody, RescalingStatusMessageParameters>
-                                        request,
+                        @Nonnull final HandlerRequest<EmptyRequestBody> request,
                         @Nonnull final RestfulGateway gateway)
                         throws RestHandlerException {
             throw featureDisabledException();
@@ -110,7 +104,7 @@ public class RescalingHandlers
 
         @Override
         protected AsynchronousJobOperationKey getOperationKey(
-                HandlerRequest<EmptyRequestBody, RescalingStatusMessageParameters> request) {
+                HandlerRequest<EmptyRequestBody> request) {
             throw new UnsupportedOperationException();
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointDisposalHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointDisposalHandlers.java
@@ -65,8 +65,7 @@ public class SavepointDisposalHandlers
 
         @Override
         protected CompletableFuture<Acknowledge> triggerOperation(
-                HandlerRequest<SavepointDisposalRequest, EmptyMessageParameters> request,
-                RestfulGateway gateway)
+                HandlerRequest<SavepointDisposalRequest> request, RestfulGateway gateway)
                 throws RestHandlerException {
             final String savepointPath = request.getRequestBody().getSavepointPath();
             if (savepointPath == null) {
@@ -81,7 +80,7 @@ public class SavepointDisposalHandlers
 
         @Override
         protected OperationKey createOperationKey(
-                HandlerRequest<SavepointDisposalRequest, EmptyMessageParameters> request) {
+                HandlerRequest<SavepointDisposalRequest> request) {
             return new OperationKey(new TriggerId());
         }
     }
@@ -105,9 +104,7 @@ public class SavepointDisposalHandlers
         }
 
         @Override
-        protected OperationKey getOperationKey(
-                HandlerRequest<EmptyRequestBody, SavepointDisposalStatusMessageParameters>
-                        request) {
+        protected OperationKey getOperationKey(HandlerRequest<EmptyRequestBody> request) {
             final TriggerId triggerId = request.getPathParameter(TriggerIdPathParameter.class);
             return new OperationKey(triggerId);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
@@ -125,8 +125,7 @@ public class SavepointHandlers
         }
 
         @Override
-        protected AsynchronousJobOperationKey createOperationKey(
-                final HandlerRequest<T, SavepointTriggerMessageParameters> request) {
+        protected AsynchronousJobOperationKey createOperationKey(final HandlerRequest<T> request) {
             final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
             return AsynchronousJobOperationKey.of(new TriggerId(), jobId);
         }
@@ -149,9 +148,7 @@ public class SavepointHandlers
 
         @Override
         protected CompletableFuture<String> triggerOperation(
-                final HandlerRequest<
-                                StopWithSavepointRequestBody, SavepointTriggerMessageParameters>
-                        request,
+                final HandlerRequest<StopWithSavepointRequestBody> request,
                 final RestfulGateway gateway)
                 throws RestHandlerException {
 
@@ -189,9 +186,7 @@ public class SavepointHandlers
 
         @Override
         protected CompletableFuture<String> triggerOperation(
-                HandlerRequest<SavepointTriggerRequestBody, SavepointTriggerMessageParameters>
-                        request,
-                RestfulGateway gateway)
+                HandlerRequest<SavepointTriggerRequestBody> request, RestfulGateway gateway)
                 throws RestHandlerException {
             final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
             final String requestedTargetDirectory = request.getRequestBody().getTargetDirectory();
@@ -228,7 +223,7 @@ public class SavepointHandlers
 
         @Override
         protected AsynchronousJobOperationKey getOperationKey(
-                HandlerRequest<EmptyRequestBody, SavepointStatusMessageParameters> request) {
+                HandlerRequest<EmptyRequestBody> request) {
             final TriggerId triggerId = request.getPathParameter(TriggerIdPathParameter.class);
             final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
             return AsynchronousJobOperationKey.of(triggerId, jobId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/resourcemanager/AbstractResourceManagerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/resourcemanager/AbstractResourceManagerHandler.java
@@ -70,7 +70,7 @@ public abstract class AbstractResourceManagerHandler<
 
     @Override
     protected CompletableFuture<P> handleRequest(
-            @Nonnull HandlerRequest<R, M> request, @Nonnull T gateway) throws RestHandlerException {
+            @Nonnull HandlerRequest<R> request, @Nonnull T gateway) throws RestHandlerException {
         ResourceManagerGateway resourceManagerGateway =
                 getResourceManagerGateway(resourceManagerGatewayRetriever);
 
@@ -78,7 +78,7 @@ public abstract class AbstractResourceManagerHandler<
     }
 
     protected abstract CompletableFuture<P> handleRequest(
-            @Nonnull HandlerRequest<R, M> request, @Nonnull ResourceManagerGateway gateway)
+            @Nonnull HandlerRequest<R> request, @Nonnull ResourceManagerGateway gateway)
             throws RestHandlerException;
 
     public static ResourceManagerGateway getResourceManagerGateway(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandler.java
@@ -108,7 +108,7 @@ public abstract class AbstractTaskManagerFileHandler<M extends TaskManagerMessag
     protected CompletableFuture<Void> respondToRequest(
             ChannelHandlerContext ctx,
             HttpRequest httpRequest,
-            HandlerRequest<EmptyRequestBody, M> handlerRequest,
+            HandlerRequest<EmptyRequestBody> handlerRequest,
             RestfulGateway gateway)
             throws RestHandlerException {
         final ResourceID taskManagerId =
@@ -216,7 +216,7 @@ public abstract class AbstractTaskManagerFileHandler<M extends TaskManagerMessag
         }
     }
 
-    protected String getFileName(HandlerRequest<EmptyRequestBody, M> handlerRequest) {
+    protected String getFileName(HandlerRequest<EmptyRequestBody> handlerRequest) {
         return null;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerCustomLogHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerCustomLogHandler.java
@@ -72,8 +72,7 @@ public class TaskManagerCustomLogHandler
     }
 
     @Override
-    protected String getFileName(
-            HandlerRequest<EmptyRequestBody, TaskManagerFileMessageParameters> handlerRequest) {
+    protected String getFileName(HandlerRequest<EmptyRequestBody> handlerRequest) {
         return handlerRequest.getPathParameter(LogFileNamePathParameter.class);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandler.java
@@ -81,7 +81,7 @@ public class TaskManagerDetailsHandler
 
     @Override
     protected CompletableFuture<TaskManagerDetailsInfo> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, TaskManagerMessageParameters> request,
+            @Nonnull HandlerRequest<EmptyRequestBody> request,
             @Nonnull ResourceManagerGateway gateway)
             throws RestHandlerException {
         final ResourceID taskManagerResourceId =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerLogListHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerLogListHandler.java
@@ -72,7 +72,7 @@ public class TaskManagerLogListHandler
 
     @Override
     protected CompletableFuture<LogListInfo> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, TaskManagerMessageParameters> request,
+            @Nonnull HandlerRequest<EmptyRequestBody> request,
             @Nonnull ResourceManagerGateway gateway)
             throws RestHandlerException {
         final ResourceID taskManagerId = request.getPathParameter(TaskManagerIdPathParameter.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerThreadDumpHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerThreadDumpHandler.java
@@ -60,7 +60,7 @@ public class TaskManagerThreadDumpHandler
 
     @Override
     protected CompletableFuture<ThreadDumpInfo> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, TaskManagerMessageParameters> request,
+            @Nonnull HandlerRequest<EmptyRequestBody> request,
             @Nonnull ResourceManagerGateway gateway)
             throws RestHandlerException {
         final ResourceID taskManagerId = request.getPathParameter(TaskManagerIdPathParameter.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagersHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagersHandler.java
@@ -57,7 +57,7 @@ public class TaskManagersHandler
 
     @Override
     protected CompletableFuture<TaskManagersInfo> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
+            @Nonnull HandlerRequest<EmptyRequestBody> request,
             @Nonnull ResourceManagerGateway gateway)
             throws RestHandlerException {
         return gateway.requestTaskManagerInfo(timeout).thenApply(TaskManagersInfo::new);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/HandlerRequestUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/HandlerRequestUtils.java
@@ -44,8 +44,7 @@ public class HandlerRequestUtils {
                     P extends MessageQueryParameter<X>,
                     R extends RequestBody,
                     M extends MessageParameters>
-            X getQueryParameter(
-                    final HandlerRequest<R, M> request, final Class<P> queryParameterClass)
+            X getQueryParameter(final HandlerRequest<R> request, final Class<P> queryParameterClass)
                     throws RestHandlerException {
 
         return getQueryParameter(request, queryParameterClass, null);
@@ -57,7 +56,7 @@ public class HandlerRequestUtils {
                     R extends RequestBody,
                     M extends MessageParameters>
             X getQueryParameter(
-                    final HandlerRequest<R, M> request,
+                    final HandlerRequest<R> request,
                     final Class<P> queryParameterClass,
                     final X defaultValue)
                     throws RestHandlerException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobCancellationMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobCancellationMessageParameters.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.rest.messages;
 
+import org.apache.flink.api.common.JobID;
+
 import java.util.Collection;
 import java.util.Collections;
 
@@ -28,8 +30,8 @@ import java.util.Collections;
  */
 public class JobCancellationMessageParameters extends MessageParameters {
 
-    public final JobIDPathParameter jobPathParameter = new JobIDPathParameter();
-    public final TerminationModeQueryParameter terminationModeQueryParameter =
+    private final JobIDPathParameter jobPathParameter = new JobIDPathParameter();
+    private final TerminationModeQueryParameter terminationModeQueryParameter =
             new TerminationModeQueryParameter();
 
     @Override
@@ -40,5 +42,16 @@ public class JobCancellationMessageParameters extends MessageParameters {
     @Override
     public Collection<MessageQueryParameter<?>> getQueryParameters() {
         return Collections.singleton(terminationModeQueryParameter);
+    }
+
+    public JobCancellationMessageParameters resolveJobId(JobID jobId) {
+        jobPathParameter.resolve(jobId);
+        return this;
+    }
+
+    public JobCancellationMessageParameters resolveTerminationMode(
+            TerminationModeQueryParameter.TerminationMode terminationMode) {
+        terminationModeQueryParameter.resolve(Collections.singletonList(terminationMode));
+        return this;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.Checkpoints;
 import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
@@ -61,6 +62,7 @@ import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.messages.FlinkJobTerminatedWithoutCancellationException;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -369,6 +371,78 @@ public class DispatcherTest extends AbstractDispatcherTest {
         assertThat(
                 dispatcherGateway.requestJobResult(jobID, TIMEOUT).get().getApplicationStatus(),
                 is(ApplicationStatus.CANCELED));
+    }
+
+    @Test
+    public void testCancellationOfCanceledTerminalDoesNotThrowException() throws Exception {
+        final CompletableFuture<JobManagerRunnerResult> jobTerminationFuture =
+                new CompletableFuture<>();
+        dispatcher =
+                createAndStartDispatcher(
+                        heartbeatServices,
+                        haServices,
+                        new FinishingJobManagerRunnerFactory(jobTerminationFuture, () -> {}));
+        jobMasterLeaderElectionService.isLeader(UUID.randomUUID());
+        DispatcherGateway dispatcherGateway = dispatcher.getSelfGateway(DispatcherGateway.class);
+
+        JobID jobId = jobGraph.getJobID();
+
+        dispatcherGateway.submitJob(jobGraph, TIMEOUT).get();
+        jobTerminationFuture.complete(
+                JobManagerRunnerResult.forSuccess(
+                        new ExecutionGraphInfo(
+                                new ArchivedExecutionGraphBuilder()
+                                        .setJobID(jobId)
+                                        .setState(JobStatus.CANCELED)
+                                        .build())));
+
+        // wait for job to finish
+        dispatcherGateway.requestJobResult(jobId, TIMEOUT).get();
+        // sanity check
+        assertThat(
+                dispatcherGateway.requestJobStatus(jobId, TIMEOUT).get(), is(JobStatus.CANCELED));
+
+        dispatcherGateway.cancelJob(jobId, TIMEOUT).get();
+    }
+
+    @Test
+    public void testCancellationOfNonCanceledTerminalJobFailsWithAppropriateException()
+            throws Exception {
+
+        final CompletableFuture<JobManagerRunnerResult> jobTerminationFuture =
+                new CompletableFuture<>();
+        dispatcher =
+                createAndStartDispatcher(
+                        heartbeatServices,
+                        haServices,
+                        new FinishingJobManagerRunnerFactory(jobTerminationFuture, () -> {}));
+        jobMasterLeaderElectionService.isLeader(UUID.randomUUID());
+        DispatcherGateway dispatcherGateway = dispatcher.getSelfGateway(DispatcherGateway.class);
+
+        JobID jobId = jobGraph.getJobID();
+
+        dispatcherGateway.submitJob(jobGraph, TIMEOUT).get();
+        jobTerminationFuture.complete(
+                JobManagerRunnerResult.forSuccess(
+                        new ExecutionGraphInfo(
+                                new ArchivedExecutionGraphBuilder()
+                                        .setJobID(jobId)
+                                        .setState(JobStatus.FINISHED)
+                                        .build())));
+
+        // wait for job to finish
+        dispatcherGateway.requestJobResult(jobId, TIMEOUT).get();
+        // sanity check
+        assertThat(
+                dispatcherGateway.requestJobStatus(jobId, TIMEOUT).get(), is(JobStatus.FINISHED));
+
+        final CompletableFuture<Acknowledge> cancelFuture =
+                dispatcherGateway.cancelJob(jobId, TIMEOUT);
+
+        assertThat(
+                cancelFuture,
+                FlinkMatchers.futureFailedWith(
+                        FlinkJobTerminatedWithoutCancellationException.class));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/FileUploadHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/FileUploadHandlerTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.rest;
 import org.apache.flink.runtime.io.network.netty.NettyLeakDetectionResource;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
-import org.apache.flink.runtime.rest.messages.MessageParameters;
 import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
@@ -395,9 +394,7 @@ public class FileUploadHandlerTest extends TestLogger {
 
     private static class CustomFilenameVerifier
             implements BiConsumerWithException<
-                    HandlerRequest<? extends RequestBody, ? extends MessageParameters>,
-                    RestfulGateway,
-                    Exception> {
+                    HandlerRequest<? extends RequestBody>, RestfulGateway, Exception> {
 
         private final String customFilename1;
         private final Path fileContent1;
@@ -419,8 +416,7 @@ public class FileUploadHandlerTest extends TestLogger {
 
         @Override
         public void accept(
-                HandlerRequest<? extends RequestBody, ? extends MessageParameters> request,
-                RestfulGateway restfulGateway)
+                HandlerRequest<? extends RequestBody> request, RestfulGateway restfulGateway)
                 throws Exception {
             List<Path> uploadedFiles =
                     request.getUploadedFiles().stream()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadResource.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
-import org.apache.flink.runtime.rest.messages.MessageParameters;
 import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.runtime.rest.util.TestRestServerEndpoint;
 import org.apache.flink.runtime.rpc.RpcUtils;
@@ -89,7 +88,7 @@ public class MultipartUploadResource extends ExternalResource {
 
     private Path configuredUploadDir;
 
-    private BiConsumerWithException<HandlerRequest<?, ?>, RestfulGateway, RestHandlerException>
+    private BiConsumerWithException<HandlerRequest<?>, RestfulGateway, RestHandlerException>
             fileUploadVerifier;
 
     @Override
@@ -167,9 +166,7 @@ public class MultipartUploadResource extends ExternalResource {
 
     public void setFileUploadVerifier(
             BiConsumerWithException<
-                            HandlerRequest<? extends RequestBody, ? extends MessageParameters>,
-                            RestfulGateway,
-                            Exception>
+                            HandlerRequest<? extends RequestBody>, RestfulGateway, Exception>
                     verifier) {
         this.fileUploadVerifier =
                 (request, restfulGateway) -> {
@@ -266,8 +263,7 @@ public class MultipartUploadResource extends ExternalResource {
 
         @Override
         protected CompletableFuture<EmptyResponseBody> handleRequest(
-                @Nonnull HandlerRequest<TestRequestBody, EmptyMessageParameters> request,
-                @Nonnull RestfulGateway gateway)
+                @Nonnull HandlerRequest<TestRequestBody> request, @Nonnull RestfulGateway gateway)
                 throws RestHandlerException {
             MultipartUploadResource.this.fileUploadVerifier.accept(request, gateway);
             this.lastReceivedRequest = request.getRequestBody();
@@ -338,8 +334,7 @@ public class MultipartUploadResource extends ExternalResource {
 
         @Override
         protected CompletableFuture<EmptyResponseBody> handleRequest(
-                @Nonnull HandlerRequest<TestRequestBody, EmptyMessageParameters> request,
-                @Nonnull RestfulGateway gateway)
+                @Nonnull HandlerRequest<TestRequestBody> request, @Nonnull RestfulGateway gateway)
                 throws RestHandlerException {
             Collection<Path> uploadedFiles =
                     request.getUploadedFiles().stream()
@@ -394,8 +389,7 @@ public class MultipartUploadResource extends ExternalResource {
 
         @Override
         protected CompletableFuture<EmptyResponseBody> handleRequest(
-                @Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
-                @Nonnull RestfulGateway gateway)
+                @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
                 throws RestHandlerException {
             MultipartUploadResource.this.fileUploadVerifier.accept(request, gateway);
             return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestMatchers.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestMatchers.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest;
+
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/** Hamcrest matchers for REST handlers. */
+public class RestMatchers {
+
+    public static <T> Matcher<CompletableFuture<T>> respondsWithError(
+            HttpResponseStatus responseStatus) {
+        return new ErrorResponseStatusCodeMatcher<>(responseStatus);
+    }
+
+    private static final class ErrorResponseStatusCodeMatcher<T>
+            extends TypeSafeDiagnosingMatcher<CompletableFuture<T>> {
+
+        private final HttpResponseStatus expectedErrorResponse;
+
+        ErrorResponseStatusCodeMatcher(HttpResponseStatus expectedErrorResponse) {
+            this.expectedErrorResponse = expectedErrorResponse;
+        }
+
+        @Override
+        protected boolean matchesSafely(
+                CompletableFuture<T> future, Description mismatchDescription) {
+            try {
+                future.get();
+
+                mismatchDescription.appendText("The request succeeded");
+                return false;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new Error("interrupted test");
+            } catch (ExecutionException e) {
+                if (e.getCause() != null) {
+                    if (RestHandlerException.class.isAssignableFrom(e.getCause().getClass())) {
+                        final RestHandlerException rhe = (RestHandlerException) e.getCause();
+                        if (rhe.getHttpResponseStatus() == expectedErrorResponse) {
+                            return true;
+                        } else {
+                            mismatchDescription.appendText(
+                                    "Error response had different status code: "
+                                            + rhe.getHttpResponseStatus());
+                            return false;
+                        }
+                    }
+                }
+
+                mismatchDescription.appendText(
+                        "Future completed with different exception: " + e.getCause());
+                return false;
+            }
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("An error response with status code: " + expectedErrorResponse);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -744,8 +744,7 @@ public class RestServerEndpointITCase extends TestLogger {
 
         @Override
         protected CompletableFuture<TestResponse> handleRequest(
-                @Nonnull HandlerRequest<TestRequest, TestParameters> request,
-                RestfulGateway gateway) {
+                @Nonnull HandlerRequest<TestRequest> request, RestfulGateway gateway) {
             assertEquals(request.getPathParameter(JobIDPathParameter.class), PATH_JOB_ID);
             assertEquals(request.getQueryParameter(JobIDQueryParameter.class).get(0), QUERY_JOB_ID);
 
@@ -967,7 +966,7 @@ public class RestServerEndpointITCase extends TestLogger {
 
         @Override
         protected CompletableFuture<EmptyResponseBody> handleRequest(
-                @Nonnull final HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
+                @Nonnull final HandlerRequest<EmptyRequestBody> request,
                 @Nonnull final RestfulGateway gateway)
                 throws RestHandlerException {
             Collection<Path> uploadedFiles =
@@ -1013,8 +1012,7 @@ public class RestServerEndpointITCase extends TestLogger {
 
         @Override
         protected CompletableFuture<EmptyResponseBody> handleRequest(
-                @Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
-                @Nonnull RestfulGateway gateway)
+                @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
                 throws RestHandlerException {
             return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/AbstractHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/AbstractHandlerTest.java
@@ -173,7 +173,7 @@ public class AbstractHandlerTest extends TestLogger {
         protected CompletableFuture<Void> respondToRequest(
                 ChannelHandlerContext ctx,
                 HttpRequest httpRequest,
-                HandlerRequest<EmptyRequestBody, EmptyMessageParameters> handlerRequest,
+                HandlerRequest<EmptyRequestBody> handlerRequest,
                 RestfulGateway gateway)
                 throws RestHandlerException {
             return completionFuture;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
@@ -222,14 +222,13 @@ public class AbstractAsynchronousOperationHandlersTest extends TestLogger {
         assertThat(closeFuture.isDone(), is(true));
     }
 
-    private static HandlerRequest<EmptyRequestBody, EmptyMessageParameters>
-            triggerOperationRequest() {
+    private static HandlerRequest<EmptyRequestBody> triggerOperationRequest() {
         return HandlerRequest.create(
                 EmptyRequestBody.getInstance(), EmptyMessageParameters.getInstance());
     }
 
-    private static HandlerRequest<EmptyRequestBody, TriggerMessageParameters>
-            statusOperationRequest(TriggerId triggerId) throws HandlerRequestException {
+    private static HandlerRequest<EmptyRequestBody> statusOperationRequest(TriggerId triggerId)
+            throws HandlerRequestException {
         return HandlerRequest.resolveParametersAndCreate(
                 EmptyRequestBody.getInstance(),
                 new TriggerMessageParameters(),
@@ -377,15 +376,14 @@ public class AbstractAsynchronousOperationHandlersTest extends TestLogger {
 
             @Override
             protected CompletableFuture<String> triggerOperation(
-                    HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
-                    RestfulGateway gateway)
+                    HandlerRequest<EmptyRequestBody> request, RestfulGateway gateway)
                     throws RestHandlerException {
                 return gateway.triggerSavepoint(new JobID(), null, false, timeout);
             }
 
             @Override
             protected TestOperationKey createOperationKey(
-                    HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request) {
+                    HandlerRequest<EmptyRequestBody> request) {
                 return new TestOperationKey(new TriggerId());
             }
         }
@@ -406,8 +404,7 @@ public class AbstractAsynchronousOperationHandlersTest extends TestLogger {
             }
 
             @Override
-            protected TestOperationKey getOperationKey(
-                    HandlerRequest<EmptyRequestBody, TriggerMessageParameters> request) {
+            protected TestOperationKey getOperationKey(HandlerRequest<EmptyRequestBody> request) {
                 final TriggerId triggerId = request.getPathParameter(TriggerIdPathParameter.class);
 
                 return new TestOperationKey(triggerId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
@@ -223,18 +223,19 @@ public class AbstractAsynchronousOperationHandlersTest extends TestLogger {
     }
 
     private static HandlerRequest<EmptyRequestBody, EmptyMessageParameters>
-            triggerOperationRequest() throws HandlerRequestException {
-        return new HandlerRequest<>(
+            triggerOperationRequest() {
+        return HandlerRequest.create(
                 EmptyRequestBody.getInstance(), EmptyMessageParameters.getInstance());
     }
 
     private static HandlerRequest<EmptyRequestBody, TriggerMessageParameters>
             statusOperationRequest(TriggerId triggerId) throws HandlerRequestException {
-        return new HandlerRequest<>(
+        return HandlerRequest.resolveParametersAndCreate(
                 EmptyRequestBody.getInstance(),
                 new TriggerMessageParameters(),
                 Collections.singletonMap(TriggerIdPathParameter.KEY, triggerId.toString()),
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                Collections.emptyList());
     }
 
     private static final class TestOperationKey extends OperationKey {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerCustomLogHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerCustomLogHandlerTest.java
@@ -96,11 +96,12 @@ public class JobManagerCustomLogHandlerTest extends TestLogger {
         Map<String, String> pathParameters = new HashMap<>();
         pathParameters.put(messageParameters.logFileNamePathParameter.getKey(), path);
 
-        return new HandlerRequest<>(
+        return HandlerRequest.resolveParametersAndCreate(
                 EmptyRequestBody.getInstance(),
                 messageParameters,
                 pathParameters,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                Collections.emptyList());
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerCustomLogHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerCustomLogHandlerTest.java
@@ -90,8 +90,8 @@ public class JobManagerCustomLogHandlerTest extends TestLogger {
         FileUtils.writeStringToFile(file, content, StandardCharsets.UTF_8);
     }
 
-    private static HandlerRequest<EmptyRequestBody, FileMessageParameters> createHandlerRequest(
-            String path) throws HandlerRequestException {
+    private static HandlerRequest<EmptyRequestBody> createHandlerRequest(String path)
+            throws HandlerRequestException {
         FileMessageParameters messageParameters = new FileMessageParameters();
         Map<String, String> pathParameters = new HashMap<>();
         pathParameters.put(messageParameters.logFileNamePathParameter.getKey(), path);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerLogListHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerLogListHandlerTest.java
@@ -66,11 +66,10 @@ public class JobManagerLogListHandlerTest extends TestLogger {
     @BeforeClass
     public static void setupClass() throws HandlerRequestException {
         testRequest =
-                new HandlerRequest<>(
+                HandlerRequest.create(
                         EmptyRequestBody.getInstance(),
                         EmptyMessageParameters.getInstance(),
-                        Collections.emptyMap(),
-                        Collections.emptyMap());
+                        Collections.emptyList());
     }
 
     @Before

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerLogListHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerLogListHandlerTest.java
@@ -57,7 +57,7 @@ import static org.junit.Assert.assertThat;
 /** Unit tests for {@link JobManagerLogListHandler}. */
 public class JobManagerLogListHandlerTest extends TestLogger {
 
-    private static HandlerRequest<EmptyRequestBody, EmptyMessageParameters> testRequest;
+    private static HandlerRequest<EmptyRequestBody> testRequest;
 
     @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobCancellationHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobCancellationHandlerTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.messages.FlinkJobTerminatedWithoutCancellationException;
+import org.apache.flink.runtime.rest.RestMatchers;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.JobCancellationHeaders;
+import org.apache.flink.runtime.rest.messages.JobCancellationMessageParameters;
+import org.apache.flink.runtime.rest.messages.TerminationModeQueryParameter;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/** Tests for the {@link JobCancellationHandler}. */
+public class JobCancellationHandlerTest extends TestLogger {
+    @Test
+    public void testSuccessfulCancellation() throws Exception {
+        testResponse(
+                jobId -> CompletableFuture.completedFuture(Acknowledge.get()),
+                CompletableFuture::get);
+    }
+
+    @Test
+    public void testErrorCodeForNonCanceledTerminalJob() throws Exception {
+        testResponseCodeOnFailedDispatcherCancellationResponse(
+                jobId ->
+                        FutureUtils.completedExceptionally(
+                                new FlinkJobTerminatedWithoutCancellationException(
+                                        jobId, JobStatus.FINISHED)),
+                HttpResponseStatus.CONFLICT);
+    }
+
+    @Test
+    public void testErrorCodeForTimeout() throws Exception {
+        testResponseCodeOnFailedDispatcherCancellationResponse(
+                jobId -> FutureUtils.completedExceptionally(new TimeoutException()),
+                HttpResponseStatus.REQUEST_TIMEOUT);
+    }
+
+    @Test
+    public void testErrorCodeForUnknownJob() throws Exception {
+        testResponseCodeOnFailedDispatcherCancellationResponse(
+                jobId -> FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId)),
+                HttpResponseStatus.NOT_FOUND);
+    }
+
+    @Test
+    public void testErrorCodeForUnknownError() throws Exception {
+        testResponseCodeOnFailedDispatcherCancellationResponse(
+                jobId -> FutureUtils.completedExceptionally(new RuntimeException()),
+                HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private static void testResponseCodeOnFailedDispatcherCancellationResponse(
+            Function<JobID, CompletableFuture<Acknowledge>> cancelJobFunction,
+            HttpResponseStatus expectedErrorCode)
+            throws Exception {
+
+        testResponse(
+                cancelJobFunction,
+                cancellationFuture ->
+                        assertThat(
+                                cancellationFuture,
+                                RestMatchers.respondsWithError(expectedErrorCode)));
+    }
+
+    private static void testResponse(
+            Function<JobID, CompletableFuture<Acknowledge>> cancelJobFunction,
+            ThrowingConsumer<CompletableFuture<EmptyResponseBody>, Exception> assertion)
+            throws Exception {
+        final RestfulGateway gateway = createGateway(cancelJobFunction);
+
+        final JobCancellationHandler jobCancellationHandler = createHandler(gateway);
+
+        final JobCancellationMessageParameters messageParameters =
+                jobCancellationHandler
+                        .getMessageHeaders()
+                        .getUnresolvedMessageParameters()
+                        .resolveJobId(new JobID());
+
+        final CompletableFuture<EmptyResponseBody> cancellationFuture =
+                jobCancellationHandler.handleRequest(
+                        HandlerRequest.create(EmptyRequestBody.getInstance(), messageParameters),
+                        gateway);
+
+        assertion.accept(cancellationFuture);
+    }
+
+    private static RestfulGateway createGateway(
+            Function<JobID, CompletableFuture<Acknowledge>> cancelJobFunction) {
+        return new TestingRestfulGateway.Builder().setCancelJobFunction(cancelJobFunction).build();
+    }
+
+    private static JobCancellationHandler createHandler(RestfulGateway gateway) {
+        return new JobCancellationHandler(
+                () -> CompletableFuture.completedFuture(gateway),
+                Time.hours(1),
+                Collections.emptyMap(),
+                JobCancellationHeaders.getInstance(),
+                TerminationModeQueryParameter.TerminationMode.CANCEL);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobConfigHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobConfigHandlerTest.java
@@ -73,7 +73,7 @@ public class JobConfigHandlerTest extends TestLogger {
                 new ArchivedExecutionGraphBuilder()
                         .setArchivedExecutionConfig(archivedExecutionConfig)
                         .build();
-        final HandlerRequest<EmptyRequestBody, JobMessageParameters> handlerRequest =
+        final HandlerRequest<EmptyRequestBody> handlerRequest =
                 createRequest(archivedExecutionGraph.getJobID());
 
         final JobConfigInfo jobConfigInfoResponse =
@@ -91,7 +91,7 @@ public class JobConfigHandlerTest extends TestLogger {
         return ConfigurationUtils.hideSensitiveValues(globalJobParameters);
     }
 
-    private HandlerRequest<EmptyRequestBody, JobMessageParameters> createRequest(JobID jobId)
+    private HandlerRequest<EmptyRequestBody> createRequest(JobID jobId)
             throws HandlerRequestException {
         final Map<String, String> pathParameters = new HashMap<>();
         pathParameters.put(JobIDPathParameter.KEY, jobId.toString());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobConfigHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobConfigHandlerTest.java
@@ -96,10 +96,11 @@ public class JobConfigHandlerTest extends TestLogger {
         final Map<String, String> pathParameters = new HashMap<>();
         pathParameters.put(JobIDPathParameter.KEY, jobId.toString());
 
-        return new HandlerRequest<>(
+        return HandlerRequest.resolveParametersAndCreate(
                 EmptyRequestBody.getInstance(),
                 new JobMessageParameters(),
                 pathParameters,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                Collections.emptyList());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
@@ -96,7 +96,7 @@ public class JobExceptionsHandlerTest extends TestLogger {
         final ExecutionGraphInfo executionGraphInfo =
                 new ExecutionGraphInfo(new ArchivedExecutionGraphBuilder().build());
 
-        final HandlerRequest<EmptyRequestBody, JobExceptionsMessageParameters> request =
+        final HandlerRequest<EmptyRequestBody> request =
                 createRequest(executionGraphInfo.getJobId(), 10);
         final JobExceptionsInfoWithHistory response =
                 testInstance.handleRequest(request, executionGraphInfo);
@@ -115,7 +115,7 @@ public class JobExceptionsHandlerTest extends TestLogger {
 
         final ExecutionGraphInfo executionGraphInfo =
                 createExecutionGraphInfo(fromGlobalFailure(rootCause, rootCauseTimestamp));
-        final HandlerRequest<EmptyRequestBody, JobExceptionsMessageParameters> request =
+        final HandlerRequest<EmptyRequestBody> request =
                 createRequest(executionGraphInfo.getJobId(), 10);
         final JobExceptionsInfoWithHistory response =
                 testInstance.handleRequest(request, executionGraphInfo);
@@ -144,7 +144,7 @@ public class JobExceptionsHandlerTest extends TestLogger {
 
         final ExecutionGraphInfo executionGraphInfo =
                 createExecutionGraphInfo(rootCause, otherFailure);
-        final HandlerRequest<EmptyRequestBody, JobExceptionsMessageParameters> request =
+        final HandlerRequest<EmptyRequestBody> request =
                 createRequest(executionGraphInfo.getJobId(), 10);
         final JobExceptionsInfoWithHistory response =
                 testInstance.handleRequest(request, executionGraphInfo);
@@ -175,7 +175,7 @@ public class JobExceptionsHandlerTest extends TestLogger {
                         Collections.emptySet());
 
         final ExecutionGraphInfo executionGraphInfo = createExecutionGraphInfo(failure);
-        final HandlerRequest<EmptyRequestBody, JobExceptionsMessageParameters> request =
+        final HandlerRequest<EmptyRequestBody> request =
                 createRequest(executionGraphInfo.getJobId(), 10);
         final JobExceptionsInfoWithHistory response =
                 testInstance.handleRequest(request, executionGraphInfo);
@@ -205,7 +205,7 @@ public class JobExceptionsHandlerTest extends TestLogger {
 
         final ExecutionGraphInfo executionGraphInfo =
                 createExecutionGraphInfo(rootCause, otherFailure);
-        final HandlerRequest<EmptyRequestBody, JobExceptionsMessageParameters> request =
+        final HandlerRequest<EmptyRequestBody> request =
                 createRequest(executionGraphInfo.getJobId(), 1);
         final JobExceptionsInfoWithHistory response =
                 testInstance.handleRequest(request, executionGraphInfo);
@@ -271,7 +271,7 @@ public class JobExceptionsHandlerTest extends TestLogger {
             int maxNumExceptions,
             int numExpectedException)
             throws HandlerRequestException {
-        final HandlerRequest<EmptyRequestBody, JobExceptionsMessageParameters> handlerRequest =
+        final HandlerRequest<EmptyRequestBody> handlerRequest =
                 createRequest(graph.getJobId(), numExpectedException);
         final JobExceptionsInfo jobExceptionsInfo =
                 jobExceptionsHandler.handleRequest(handlerRequest, graph);
@@ -370,8 +370,8 @@ public class JobExceptionsHandlerTest extends TestLogger {
         return new ExecutionGraphInfo(executionGraphBuilder.build(), historyEntryCollection);
     }
 
-    private static HandlerRequest<EmptyRequestBody, JobExceptionsMessageParameters> createRequest(
-            JobID jobId, int size) throws HandlerRequestException {
+    private static HandlerRequest<EmptyRequestBody> createRequest(JobID jobId, int size)
+            throws HandlerRequestException {
         final Map<String, String> pathParameters = new HashMap<>();
         pathParameters.put(JobIDPathParameter.KEY, jobId.toString());
         final Map<String, List<String>> queryParameters = new HashMap<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
@@ -377,11 +377,12 @@ public class JobExceptionsHandlerTest extends TestLogger {
         final Map<String, List<String>> queryParameters = new HashMap<>();
         queryParameters.put(UpperLimitExceptionParameter.KEY, Collections.singletonList("" + size));
 
-        return new HandlerRequest<>(
+        return HandlerRequest.resolveParametersAndCreate(
                 EmptyRequestBody.getInstance(),
                 new JobExceptionsMessageParameters(),
                 pathParameters,
-                queryParameters);
+                queryParameters,
+                Collections.emptyList());
     }
 
     private static RootExceptionHistoryEntry fromGlobalFailure(Throwable cause, long timestamp) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExecutionResultHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExecutionResultHandlerTest.java
@@ -73,11 +73,12 @@ public class JobExecutionResultHandlerTest extends TestLogger {
                         Collections.emptyMap());
 
         testRequest =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         new JobMessageParameters(),
                         Collections.singletonMap("jobid", TEST_JOB_ID.toString()),
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Collections.emptyList());
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExecutionResultHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExecutionResultHandlerTest.java
@@ -59,7 +59,7 @@ public class JobExecutionResultHandlerTest extends TestLogger {
 
     private JobExecutionResultHandler jobExecutionResultHandler;
 
-    private HandlerRequest<EmptyRequestBody, JobMessageParameters> testRequest;
+    private HandlerRequest<EmptyRequestBody> testRequest;
 
     @Before
     public void setUp() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
@@ -128,7 +128,7 @@ public class JobSubmitHandlerTest extends TestLogger {
 
         try {
             handler.handleRequest(
-                    new HandlerRequest<>(request, EmptyMessageParameters.getInstance()),
+                    HandlerRequest.create(request, EmptyMessageParameters.getInstance()),
                     mockGateway);
             Assert.fail();
         } catch (RestHandlerException rhe) {
@@ -165,11 +165,9 @@ public class JobSubmitHandlerTest extends TestLogger {
                         Collections.emptyList());
 
         handler.handleRequest(
-                        new HandlerRequest<>(
+                        HandlerRequest.create(
                                 request,
                                 EmptyMessageParameters.getInstance(),
-                                Collections.emptyMap(),
-                                Collections.emptyMap(),
                                 Collections.singleton(jobGraphFile.toFile())),
                         mockGateway)
                 .get();
@@ -206,11 +204,9 @@ public class JobSubmitHandlerTest extends TestLogger {
 
         try {
             handler.handleRequest(
-                            new HandlerRequest<>(
+                            HandlerRequest.create(
                                     request,
                                     EmptyMessageParameters.getInstance(),
-                                    Collections.emptyMap(),
-                                    Collections.emptyMap(),
                                     Arrays.asList(
                                             jobGraphFile.toFile(), countExceedingFile.toFile())),
                             mockGateway)
@@ -269,11 +265,9 @@ public class JobSubmitHandlerTest extends TestLogger {
                                         dcEntryName, artifactFile.getFileName().toString())));
 
         handler.handleRequest(
-                        new HandlerRequest<>(
+                        HandlerRequest.create(
                                 request,
                                 EmptyMessageParameters.getInstance(),
-                                Collections.emptyMap(),
-                                Collections.emptyMap(),
                                 Arrays.asList(
                                         jobGraphFile.toFile(),
                                         jarFile.toFile(),
@@ -322,11 +316,9 @@ public class JobSubmitHandlerTest extends TestLogger {
 
         try {
             handler.handleRequest(
-                            new HandlerRequest<>(
+                            HandlerRequest.create(
                                     request,
                                     EmptyMessageParameters.getInstance(),
-                                    Collections.emptyMap(),
-                                    Collections.emptyMap(),
                                     Collections.singletonList(jobGraphFile.toFile())),
                             mockGateway)
                     .get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandlerTest.java
@@ -147,7 +147,7 @@ public class JobVertexBackPressureHandlerTest {
                 JobIDPathParameter.KEY, TEST_JOB_ID_BACK_PRESSURE_STATS_AVAILABLE.toString());
         pathParameters.put(JobVertexIdPathParameter.KEY, TEST_JOB_VERTEX_ID.toString());
 
-        final HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request =
+        final HandlerRequest<EmptyRequestBody> request =
                 HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         new JobVertexMessageParameters(),
@@ -202,7 +202,7 @@ public class JobVertexBackPressureHandlerTest {
                 JobIDPathParameter.KEY, TEST_JOB_ID_BACK_PRESSURE_STATS_ABSENT.toString());
         pathParameters.put(JobVertexIdPathParameter.KEY, new JobVertexID().toString());
 
-        final HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request =
+        final HandlerRequest<EmptyRequestBody> request =
                 HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         new JobVertexMessageParameters(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandlerTest.java
@@ -148,11 +148,12 @@ public class JobVertexBackPressureHandlerTest {
         pathParameters.put(JobVertexIdPathParameter.KEY, TEST_JOB_VERTEX_ID.toString());
 
         final HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         new JobVertexMessageParameters(),
                         pathParameters,
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Collections.emptyList());
 
         final CompletableFuture<JobVertexBackPressureInfo>
                 jobVertexBackPressureInfoCompletableFuture =
@@ -202,11 +203,12 @@ public class JobVertexBackPressureHandlerTest {
         pathParameters.put(JobVertexIdPathParameter.KEY, new JobVertexID().toString());
 
         final HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         new JobVertexMessageParameters(),
                         pathParameters,
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Collections.emptyList());
 
         final CompletableFuture<JobVertexBackPressureInfo>
                 jobVertexBackPressureInfoCompletableFuture =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
@@ -134,7 +134,7 @@ public class SubtaskCurrentAttemptDetailsHandlerTest extends TestLogger {
         receivedPathParameters.put(JobIDPathParameter.KEY, jobID.toString());
         receivedPathParameters.put(JobVertexIdPathParameter.KEY, jobVertexID.toString());
 
-        final HandlerRequest<EmptyRequestBody, SubtaskMessageParameters> request =
+        final HandlerRequest<EmptyRequestBody> request =
                 HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         new SubtaskMessageParameters(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
@@ -135,11 +135,12 @@ public class SubtaskCurrentAttemptDetailsHandlerTest extends TestLogger {
         receivedPathParameters.put(JobVertexIdPathParameter.KEY, jobVertexID.toString());
 
         final HandlerRequest<EmptyRequestBody, SubtaskMessageParameters> request =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         new SubtaskMessageParameters(),
                         receivedPathParameters,
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Collections.emptyList());
 
         // Handle request.
         final SubtaskExecutionAttemptDetailsInfo detailsInfo =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
@@ -72,7 +72,7 @@ public class SubtaskExecutionAttemptAccumulatorsHandlerTest extends TestLogger {
 
         // Instance a empty request.
         final HandlerRequest<EmptyRequestBody, SubtaskAttemptMessageParameters> request =
-                new HandlerRequest<>(
+                HandlerRequest.create(
                         EmptyRequestBody.getInstance(), new SubtaskAttemptMessageParameters());
 
         final Map<String, OptionalFailure<Accumulator<?, ?>>> userAccumulators = new HashMap<>(3);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
@@ -71,7 +71,7 @@ public class SubtaskExecutionAttemptAccumulatorsHandlerTest extends TestLogger {
                         TestingUtils.defaultExecutor());
 
         // Instance a empty request.
-        final HandlerRequest<EmptyRequestBody, SubtaskAttemptMessageParameters> request =
+        final HandlerRequest<EmptyRequestBody> request =
                 HandlerRequest.create(
                         EmptyRequestBody.getInstance(), new SubtaskAttemptMessageParameters());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
@@ -138,7 +138,7 @@ public class SubtaskExecutionAttemptDetailsHandlerTest extends TestLogger {
         receivedPathParameters.put(SubtaskIndexPathParameter.KEY, Integer.toString(subtaskIndex));
         receivedPathParameters.put(SubtaskAttemptPathParameter.KEY, Integer.toString(attempt));
 
-        final HandlerRequest<EmptyRequestBody, SubtaskAttemptMessageParameters> request =
+        final HandlerRequest<EmptyRequestBody> request =
                 HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         new SubtaskAttemptMessageParameters(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
@@ -139,11 +139,12 @@ public class SubtaskExecutionAttemptDetailsHandlerTest extends TestLogger {
         receivedPathParameters.put(SubtaskAttemptPathParameter.KEY, Integer.toString(attempt));
 
         final HandlerRequest<EmptyRequestBody, SubtaskAttemptMessageParameters> request =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         new SubtaskAttemptMessageParameters(),
                         receivedPathParameters,
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Collections.emptyList());
 
         // Handle request.
         final SubtaskExecutionAttemptDetailsInfo detailsInfo =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractMetricsHandlerTest.java
@@ -102,11 +102,10 @@ public class AbstractMetricsHandlerTest extends TestLogger {
     public void testListMetrics() throws Exception {
         final CompletableFuture<MetricCollectionResponseBody> completableFuture =
                 testMetricsHandler.handleRequest(
-                        new HandlerRequest<>(
+                        HandlerRequest.create(
                                 EmptyRequestBody.getInstance(),
                                 new TestMessageParameters(),
-                                Collections.emptyMap(),
-                                Collections.emptyMap()),
+                                Collections.emptyList()),
                         mockDispatcherGateway);
 
         assertTrue(completableFuture.isDone());
@@ -125,11 +124,10 @@ public class AbstractMetricsHandlerTest extends TestLogger {
 
         final CompletableFuture<MetricCollectionResponseBody> completableFuture =
                 testMetricsHandler.handleRequest(
-                        new HandlerRequest<>(
+                        HandlerRequest.create(
                                 EmptyRequestBody.getInstance(),
                                 new TestMessageParameters(),
-                                Collections.emptyMap(),
-                                Collections.emptyMap()),
+                                Collections.emptyList()),
                         mockDispatcherGateway);
 
         assertTrue(completableFuture.isDone());
@@ -142,13 +140,14 @@ public class AbstractMetricsHandlerTest extends TestLogger {
     public void testGetMetrics() throws Exception {
         final CompletableFuture<MetricCollectionResponseBody> completableFuture =
                 testMetricsHandler.handleRequest(
-                        new HandlerRequest<>(
+                        HandlerRequest.resolveParametersAndCreate(
                                 EmptyRequestBody.getInstance(),
                                 new TestMessageParameters(),
                                 Collections.emptyMap(),
                                 Collections.singletonMap(
                                         METRICS_FILTER_QUERY_PARAM,
-                                        Collections.singletonList(TEST_METRIC_NAME))),
+                                        Collections.singletonList(TEST_METRIC_NAME)),
+                                Collections.emptyList()),
                         mockDispatcherGateway);
 
         assertTrue(completableFuture.isDone());
@@ -165,13 +164,14 @@ public class AbstractMetricsHandlerTest extends TestLogger {
     public void testReturnEmptyListIfRequestedMetricIsUnknown() throws Exception {
         final CompletableFuture<MetricCollectionResponseBody> completableFuture =
                 testMetricsHandler.handleRequest(
-                        new HandlerRequest<>(
+                        HandlerRequest.resolveParametersAndCreate(
                                 EmptyRequestBody.getInstance(),
                                 new TestMessageParameters(),
                                 Collections.emptyMap(),
                                 Collections.singletonMap(
                                         METRICS_FILTER_QUERY_PARAM,
-                                        Collections.singletonList("unknown_metric"))),
+                                        Collections.singletonList("unknown_metric")),
+                                Collections.emptyList()),
                         mockDispatcherGateway);
 
         assertTrue(completableFuture.isDone());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractMetricsHandlerTest.java
@@ -201,8 +201,7 @@ public class AbstractMetricsHandlerTest extends TestLogger {
         @Nullable
         @Override
         protected MetricStore.ComponentMetricStore getComponentMetricStore(
-                HandlerRequest<EmptyRequestBody, TestMessageParameters> request,
-                MetricStore metricStore) {
+                HandlerRequest<EmptyRequestBody> request, MetricStore metricStore) {
             return returnComponentMetricStore ? metricStore.getJobManager() : null;
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractMetricsHandlerTest.java
@@ -227,6 +227,8 @@ public class AbstractMetricsHandlerTest extends TestLogger {
 
     private static class TestMessageParameters extends MessageParameters {
 
+        private final MetricsFilterParameter metricsFilterParameter = new MetricsFilterParameter();
+
         @Override
         public Collection<MessagePathParameter<?>> getPathParameters() {
             return Collections.emptyList();
@@ -234,7 +236,7 @@ public class AbstractMetricsHandlerTest extends TestLogger {
 
         @Override
         public Collection<MessageQueryParameter<?>> getQueryParameters() {
-            return Collections.singletonList(new MetricsFilterParameter());
+            return Collections.singletonList(metricsFilterParameter);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AggregatingMetricsHandlerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AggregatingMetricsHandlerTestBase.java
@@ -125,7 +125,7 @@ public abstract class AggregatingMetricsHandlerTestBase<
     @Test
     public void getStores() throws Exception {
         { // test without filter
-            HandlerRequest<EmptyRequestBody, P> request =
+            HandlerRequest<EmptyRequestBody> request =
                     HandlerRequest.resolveParametersAndCreate(
                             EmptyRequestBody.getInstance(),
                             handler.getMessageHeaders().getUnresolvedMessageParameters(),
@@ -165,7 +165,7 @@ public abstract class AggregatingMetricsHandlerTestBase<
             Tuple2<String, List<String>> filter = getFilter();
             Map<String, List<String>> queryParameters = new HashMap<>(4);
             queryParameters.put(filter.f0, filter.f1);
-            HandlerRequest<EmptyRequestBody, P> request =
+            HandlerRequest<EmptyRequestBody> request =
                     HandlerRequest.resolveParametersAndCreate(
                             EmptyRequestBody.getInstance(),
                             handler.getMessageHeaders().getUnresolvedMessageParameters(),
@@ -203,7 +203,7 @@ public abstract class AggregatingMetricsHandlerTestBase<
 
     @Test
     public void testListMetrics() throws Exception {
-        HandlerRequest<EmptyRequestBody, P> request =
+        HandlerRequest<EmptyRequestBody> request =
                 HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         handler.getMessageHeaders().getUnresolvedMessageParameters(),
@@ -231,7 +231,7 @@ public abstract class AggregatingMetricsHandlerTestBase<
         queryParams.put("get", Collections.singletonList("abc.metric1"));
         queryParams.put("agg", Collections.singletonList("min"));
 
-        HandlerRequest<EmptyRequestBody, P> request =
+        HandlerRequest<EmptyRequestBody> request =
                 HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         handler.getMessageHeaders().getUnresolvedMessageParameters(),
@@ -260,7 +260,7 @@ public abstract class AggregatingMetricsHandlerTestBase<
         queryParams.put("get", Collections.singletonList("abc.metric1"));
         queryParams.put("agg", Collections.singletonList("max"));
 
-        HandlerRequest<EmptyRequestBody, P> request =
+        HandlerRequest<EmptyRequestBody> request =
                 HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         handler.getMessageHeaders().getUnresolvedMessageParameters(),
@@ -289,7 +289,7 @@ public abstract class AggregatingMetricsHandlerTestBase<
         queryParams.put("get", Collections.singletonList("abc.metric1"));
         queryParams.put("agg", Collections.singletonList("sum"));
 
-        HandlerRequest<EmptyRequestBody, P> request =
+        HandlerRequest<EmptyRequestBody> request =
                 HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         handler.getMessageHeaders().getUnresolvedMessageParameters(),
@@ -318,7 +318,7 @@ public abstract class AggregatingMetricsHandlerTestBase<
         queryParams.put("get", Collections.singletonList("abc.metric1"));
         queryParams.put("agg", Collections.singletonList("avg"));
 
-        HandlerRequest<EmptyRequestBody, P> request =
+        HandlerRequest<EmptyRequestBody> request =
                 HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         handler.getMessageHeaders().getUnresolvedMessageParameters(),
@@ -347,7 +347,7 @@ public abstract class AggregatingMetricsHandlerTestBase<
         queryParams.put("get", Collections.singletonList("abc.metric1"));
         queryParams.put("agg", Arrays.asList("min", "max", "avg"));
 
-        HandlerRequest<EmptyRequestBody, P> request =
+        HandlerRequest<EmptyRequestBody> request =
                 HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         handler.getMessageHeaders().getUnresolvedMessageParameters(),
@@ -375,7 +375,7 @@ public abstract class AggregatingMetricsHandlerTestBase<
         Map<String, List<String>> queryParams = new HashMap<>(4);
         queryParams.put("get", Collections.singletonList("abc.metric1"));
 
-        HandlerRequest<EmptyRequestBody, P> request =
+        HandlerRequest<EmptyRequestBody> request =
                 HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         handler.getMessageHeaders().getUnresolvedMessageParameters(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AggregatingMetricsHandlerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AggregatingMetricsHandlerTestBase.java
@@ -126,11 +126,12 @@ public abstract class AggregatingMetricsHandlerTestBase<
     public void getStores() throws Exception {
         { // test without filter
             HandlerRequest<EmptyRequestBody, P> request =
-                    new HandlerRequest<>(
+                    HandlerRequest.resolveParametersAndCreate(
                             EmptyRequestBody.getInstance(),
                             handler.getMessageHeaders().getUnresolvedMessageParameters(),
                             pathParameters,
-                            Collections.emptyMap());
+                            Collections.emptyMap(),
+                            Collections.emptyList());
             Collection<? extends MetricStore.ComponentMetricStore> subStores =
                     handler.getStores(store, request);
 
@@ -165,11 +166,12 @@ public abstract class AggregatingMetricsHandlerTestBase<
             Map<String, List<String>> queryParameters = new HashMap<>(4);
             queryParameters.put(filter.f0, filter.f1);
             HandlerRequest<EmptyRequestBody, P> request =
-                    new HandlerRequest<>(
+                    HandlerRequest.resolveParametersAndCreate(
                             EmptyRequestBody.getInstance(),
                             handler.getMessageHeaders().getUnresolvedMessageParameters(),
                             pathParameters,
-                            queryParameters);
+                            queryParameters,
+                            Collections.emptyList());
             Collection<? extends MetricStore.ComponentMetricStore> subStores =
                     handler.getStores(store, request);
 
@@ -202,11 +204,12 @@ public abstract class AggregatingMetricsHandlerTestBase<
     @Test
     public void testListMetrics() throws Exception {
         HandlerRequest<EmptyRequestBody, P> request =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         handler.getMessageHeaders().getUnresolvedMessageParameters(),
                         pathParameters,
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Collections.emptyList());
 
         AggregatedMetricsResponseBody response =
                 handler.handleRequest(request, MOCK_DISPATCHER_GATEWAY).get();
@@ -229,11 +232,12 @@ public abstract class AggregatingMetricsHandlerTestBase<
         queryParams.put("agg", Collections.singletonList("min"));
 
         HandlerRequest<EmptyRequestBody, P> request =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         handler.getMessageHeaders().getUnresolvedMessageParameters(),
                         pathParameters,
-                        queryParams);
+                        queryParams,
+                        Collections.emptyList());
 
         AggregatedMetricsResponseBody response =
                 handler.handleRequest(request, MOCK_DISPATCHER_GATEWAY).get();
@@ -257,11 +261,12 @@ public abstract class AggregatingMetricsHandlerTestBase<
         queryParams.put("agg", Collections.singletonList("max"));
 
         HandlerRequest<EmptyRequestBody, P> request =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         handler.getMessageHeaders().getUnresolvedMessageParameters(),
                         pathParameters,
-                        queryParams);
+                        queryParams,
+                        Collections.emptyList());
 
         AggregatedMetricsResponseBody response =
                 handler.handleRequest(request, MOCK_DISPATCHER_GATEWAY).get();
@@ -285,11 +290,12 @@ public abstract class AggregatingMetricsHandlerTestBase<
         queryParams.put("agg", Collections.singletonList("sum"));
 
         HandlerRequest<EmptyRequestBody, P> request =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         handler.getMessageHeaders().getUnresolvedMessageParameters(),
                         pathParameters,
-                        queryParams);
+                        queryParams,
+                        Collections.emptyList());
 
         AggregatedMetricsResponseBody response =
                 handler.handleRequest(request, MOCK_DISPATCHER_GATEWAY).get();
@@ -313,11 +319,12 @@ public abstract class AggregatingMetricsHandlerTestBase<
         queryParams.put("agg", Collections.singletonList("avg"));
 
         HandlerRequest<EmptyRequestBody, P> request =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         handler.getMessageHeaders().getUnresolvedMessageParameters(),
                         pathParameters,
-                        queryParams);
+                        queryParams,
+                        Collections.emptyList());
 
         AggregatedMetricsResponseBody response =
                 handler.handleRequest(request, MOCK_DISPATCHER_GATEWAY).get();
@@ -341,11 +348,12 @@ public abstract class AggregatingMetricsHandlerTestBase<
         queryParams.put("agg", Arrays.asList("min", "max", "avg"));
 
         HandlerRequest<EmptyRequestBody, P> request =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         handler.getMessageHeaders().getUnresolvedMessageParameters(),
                         pathParameters,
-                        queryParams);
+                        queryParams,
+                        Collections.emptyList());
 
         AggregatedMetricsResponseBody response =
                 handler.handleRequest(request, MOCK_DISPATCHER_GATEWAY).get();
@@ -368,11 +376,12 @@ public abstract class AggregatingMetricsHandlerTestBase<
         queryParams.put("get", Collections.singletonList("abc.metric1"));
 
         HandlerRequest<EmptyRequestBody, P> request =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         handler.getMessageHeaders().getUnresolvedMessageParameters(),
                         pathParameters,
-                        queryParams);
+                        queryParams,
+                        Collections.emptyList());
 
         AggregatedMetricsResponseBody response =
                 handler.handleRequest(request, MOCK_DISPATCHER_GATEWAY).get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/JobVertexWatermarksHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/JobVertexWatermarksHandlerTest.java
@@ -66,7 +66,7 @@ public class JobVertexWatermarksHandlerTest {
     private MetricFetcher metricFetcher;
     private MetricStore.TaskMetricStore taskMetricStore;
     private JobVertexWatermarksHandler watermarkHandler;
-    private HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request;
+    private HandlerRequest<EmptyRequestBody> request;
     private AccessExecutionJobVertex vertex;
 
     @Before

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/JobVertexWatermarksHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/JobVertexWatermarksHandlerTest.java
@@ -96,11 +96,12 @@ public class JobVertexWatermarksHandlerTest {
         pathParameters.put(JobVertexIdPathParameter.KEY, TEST_VERTEX_ID.toString());
 
         request =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         new JobVertexMessageParameters(),
                         pathParameters,
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Collections.emptyList());
 
         vertex = Mockito.mock(AccessExecutionJobVertex.class);
         Mockito.when(vertex.getJobVertexId()).thenReturn(TEST_VERTEX_ID);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/MetricsHandlerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/MetricsHandlerTestBase.java
@@ -101,11 +101,12 @@ public abstract class MetricsHandlerTestBase<T extends AbstractMetricsHandler> e
         @SuppressWarnings("unchecked")
         final CompletableFuture<MetricCollectionResponseBody> completableFuture =
                 metricsHandler.handleRequest(
-                        new HandlerRequest<>(
+                        HandlerRequest.resolveParametersAndCreate(
                                 EmptyRequestBody.getInstance(),
                                 metricsHandler.getMessageHeaders().getUnresolvedMessageParameters(),
                                 pathParameters,
-                                Collections.emptyMap()),
+                                Collections.emptyMap(),
+                                Collections.emptyList()),
                         mockDispatcherGateway);
 
         assertTrue(completableFuture.isDone());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
@@ -200,18 +200,18 @@ public class SavepointHandlersTest extends TestLogger {
         assertThat(savepointError, instanceOf(RuntimeException.class));
     }
 
-    private static HandlerRequest<SavepointTriggerRequestBody, SavepointTriggerMessageParameters>
-            triggerSavepointRequest() throws HandlerRequestException {
+    private static HandlerRequest<SavepointTriggerRequestBody> triggerSavepointRequest()
+            throws HandlerRequestException {
         return triggerSavepointRequest(DEFAULT_REQUESTED_SAVEPOINT_TARGET_DIRECTORY);
     }
 
-    private static HandlerRequest<SavepointTriggerRequestBody, SavepointTriggerMessageParameters>
+    private static HandlerRequest<SavepointTriggerRequestBody>
             triggerSavepointRequestWithDefaultDirectory() throws HandlerRequestException {
         return triggerSavepointRequest(null);
     }
 
-    private static HandlerRequest<SavepointTriggerRequestBody, SavepointTriggerMessageParameters>
-            triggerSavepointRequest(final String targetDirectory) throws HandlerRequestException {
+    private static HandlerRequest<SavepointTriggerRequestBody> triggerSavepointRequest(
+            final String targetDirectory) throws HandlerRequestException {
         return HandlerRequest.resolveParametersAndCreate(
                 new SavepointTriggerRequestBody(targetDirectory, false),
                 new SavepointTriggerMessageParameters(),
@@ -220,8 +220,8 @@ public class SavepointHandlersTest extends TestLogger {
                 Collections.emptyList());
     }
 
-    private static HandlerRequest<EmptyRequestBody, SavepointStatusMessageParameters>
-            savepointStatusRequest(final TriggerId triggerId) throws HandlerRequestException {
+    private static HandlerRequest<EmptyRequestBody> savepointStatusRequest(
+            final TriggerId triggerId) throws HandlerRequestException {
         final Map<String, String> pathParameters = new HashMap<>();
         pathParameters.put(JobIDPathParameter.KEY, JOB_ID.toString());
         pathParameters.put(TriggerIdPathParameter.KEY, triggerId.toString());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
@@ -212,11 +212,12 @@ public class SavepointHandlersTest extends TestLogger {
 
     private static HandlerRequest<SavepointTriggerRequestBody, SavepointTriggerMessageParameters>
             triggerSavepointRequest(final String targetDirectory) throws HandlerRequestException {
-        return new HandlerRequest<>(
+        return HandlerRequest.resolveParametersAndCreate(
                 new SavepointTriggerRequestBody(targetDirectory, false),
                 new SavepointTriggerMessageParameters(),
                 Collections.singletonMap(JobIDPathParameter.KEY, JOB_ID.toString()),
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                Collections.emptyList());
     }
 
     private static HandlerRequest<EmptyRequestBody, SavepointStatusMessageParameters>
@@ -225,10 +226,11 @@ public class SavepointHandlersTest extends TestLogger {
         pathParameters.put(JobIDPathParameter.KEY, JOB_ID.toString());
         pathParameters.put(TriggerIdPathParameter.KEY, triggerId.toString());
 
-        return new HandlerRequest<>(
+        return HandlerRequest.resolveParametersAndCreate(
                 EmptyRequestBody.getInstance(),
                 new SavepointStatusMessageParameters(),
                 pathParameters,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                Collections.emptyList());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/StopWithSavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/StopWithSavepointHandlersTest.java
@@ -217,11 +217,12 @@ public class StopWithSavepointHandlersTest extends TestLogger {
 
     private static HandlerRequest<StopWithSavepointRequestBody, SavepointTriggerMessageParameters>
             triggerSavepointRequest(final String targetDirectory) throws HandlerRequestException {
-        return new HandlerRequest<>(
+        return HandlerRequest.resolveParametersAndCreate(
                 new StopWithSavepointRequestBody(targetDirectory, false),
                 new SavepointTriggerMessageParameters(),
                 Collections.singletonMap(JobIDPathParameter.KEY, JOB_ID.toString()),
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                Collections.emptyList());
     }
 
     private static HandlerRequest<EmptyRequestBody, SavepointStatusMessageParameters>
@@ -230,10 +231,11 @@ public class StopWithSavepointHandlersTest extends TestLogger {
         pathParameters.put(JobIDPathParameter.KEY, JOB_ID.toString());
         pathParameters.put(TriggerIdPathParameter.KEY, triggerId.toString());
 
-        return new HandlerRequest<>(
+        return HandlerRequest.resolveParametersAndCreate(
                 EmptyRequestBody.getInstance(),
                 new SavepointStatusMessageParameters(),
                 pathParameters,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                Collections.emptyList());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/StopWithSavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/StopWithSavepointHandlersTest.java
@@ -205,18 +205,18 @@ public class StopWithSavepointHandlersTest extends TestLogger {
         assertThat(savepointError, instanceOf(RuntimeException.class));
     }
 
-    private static HandlerRequest<StopWithSavepointRequestBody, SavepointTriggerMessageParameters>
-            triggerSavepointRequest() throws HandlerRequestException {
+    private static HandlerRequest<StopWithSavepointRequestBody> triggerSavepointRequest()
+            throws HandlerRequestException {
         return triggerSavepointRequest(DEFAULT_REQUESTED_SAVEPOINT_TARGET_DIRECTORY);
     }
 
-    private static HandlerRequest<StopWithSavepointRequestBody, SavepointTriggerMessageParameters>
+    private static HandlerRequest<StopWithSavepointRequestBody>
             triggerSavepointRequestWithDefaultDirectory() throws HandlerRequestException {
         return triggerSavepointRequest(null);
     }
 
-    private static HandlerRequest<StopWithSavepointRequestBody, SavepointTriggerMessageParameters>
-            triggerSavepointRequest(final String targetDirectory) throws HandlerRequestException {
+    private static HandlerRequest<StopWithSavepointRequestBody> triggerSavepointRequest(
+            final String targetDirectory) throws HandlerRequestException {
         return HandlerRequest.resolveParametersAndCreate(
                 new StopWithSavepointRequestBody(targetDirectory, false),
                 new SavepointTriggerMessageParameters(),
@@ -225,8 +225,8 @@ public class StopWithSavepointHandlersTest extends TestLogger {
                 Collections.emptyList());
     }
 
-    private static HandlerRequest<EmptyRequestBody, SavepointStatusMessageParameters>
-            savepointStatusRequest(final TriggerId triggerId) throws HandlerRequestException {
+    private static HandlerRequest<EmptyRequestBody> savepointStatusRequest(
+            final TriggerId triggerId) throws HandlerRequestException {
         final Map<String, String> pathParameters = new HashMap<>();
         pathParameters.put(JobIDPathParameter.KEY, JOB_ID.toString());
         pathParameters.put(TriggerIdPathParameter.KEY, triggerId.toString());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandlerTest.java
@@ -124,13 +124,14 @@ public class AbstractTaskManagerFileHandlerTest extends TestLogger {
         blobServer = new BlobServer(configuration, new VoidBlobStore());
 
         handlerRequest =
-                new HandlerRequest<>(
+                HandlerRequest.resolveParametersAndCreate(
                         EmptyRequestBody.getInstance(),
                         new TaskManagerFileMessageParameters(),
                         Collections.singletonMap(
                                 TaskManagerIdPathParameter.KEY,
                                 EXPECTED_TASK_MANAGER_ID.getResourceIdString()),
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Collections.emptyList());
     }
 
     @Before

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandlerTest.java
@@ -105,7 +105,7 @@ public class AbstractTaskManagerFileHandlerTest extends TestLogger {
 
     private static BlobServer blobServer;
 
-    private static HandlerRequest<EmptyRequestBody, TaskManagerMessageParameters> handlerRequest;
+    private static HandlerRequest<EmptyRequestBody> handlerRequest;
 
     private String fileContent1;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandlerTest.java
@@ -36,7 +36,6 @@ import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerDetailsInfo
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerFileMessageParameters;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerIdPathParameter;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
-import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerMessageParameters;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerMetricsInfo;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.runtime.testutils.TestingUtils;
@@ -94,7 +93,7 @@ public class TaskManagerDetailsHandlerTest extends TestLogger {
                                 new TaskManagerInfoWithSlots(
                                         createEmptyTaskManagerInfo(), Collections.emptyList())));
 
-        HandlerRequest<EmptyRequestBody, TaskManagerMessageParameters> request = createRequest();
+        HandlerRequest<EmptyRequestBody> request = createRequest();
         TaskManagerDetailsInfo taskManagerDetailsInfo =
                 testInstance.handleRequest(request, resourceManagerGateway).get();
 
@@ -178,8 +177,7 @@ public class TaskManagerDetailsHandlerTest extends TestLogger {
                 new TaskExecutorMemoryConfiguration(0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L));
     }
 
-    private static HandlerRequest<EmptyRequestBody, TaskManagerMessageParameters> createRequest()
-            throws HandlerRequestException {
+    private static HandlerRequest<EmptyRequestBody> createRequest() throws HandlerRequestException {
         Map<String, String> pathParameters = new HashMap<>();
         pathParameters.put(TaskManagerIdPathParameter.KEY, TASK_MANAGER_ID.toString());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandlerTest.java
@@ -183,11 +183,12 @@ public class TaskManagerDetailsHandlerTest extends TestLogger {
         Map<String, String> pathParameters = new HashMap<>();
         pathParameters.put(TaskManagerIdPathParameter.KEY, TASK_MANAGER_ID.toString());
 
-        return new HandlerRequest<>(
+        return HandlerRequest.resolveParametersAndCreate(
                 EmptyRequestBody.getInstance(),
                 new TaskManagerFileMessageParameters(),
                 pathParameters,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                Collections.emptyList());
     }
 
     private static class TestingMetricFetcher implements MetricFetcher {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerLogListHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerLogListHandlerTest.java
@@ -119,10 +119,11 @@ public class TaskManagerLogListHandlerTest extends TestLogger {
         pathParameters.put(TaskManagerIdPathParameter.KEY, taskManagerId.toString());
         Map<String, List<String>> queryParameters = Collections.emptyMap();
 
-        return new HandlerRequest<>(
+        return HandlerRequest.resolveParametersAndCreate(
                 EmptyRequestBody.getInstance(),
                 new TaskManagerMessageParameters(),
                 pathParameters,
-                queryParameters);
+                queryParameters,
+                Collections.emptyList());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerLogListHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerLogListHandlerTest.java
@@ -60,7 +60,7 @@ public class TaskManagerLogListHandlerTest extends TestLogger {
     private static final ResourceID EXPECTED_TASK_MANAGER_ID = ResourceID.generate();
     private TestingResourceManagerGateway resourceManagerGateway;
     private TaskManagerLogListHandler taskManagerLogListHandler;
-    private HandlerRequest<EmptyRequestBody, TaskManagerMessageParameters> handlerRequest;
+    private HandlerRequest<EmptyRequestBody> handlerRequest;
 
     @Before
     public void setUp() throws HandlerRequestException {
@@ -113,8 +113,8 @@ public class TaskManagerLogListHandlerTest extends TestLogger {
         }
     }
 
-    private static HandlerRequest<EmptyRequestBody, TaskManagerMessageParameters> createRequest(
-            ResourceID taskManagerId) throws HandlerRequestException {
+    private static HandlerRequest<EmptyRequestBody> createRequest(ResourceID taskManagerId)
+            throws HandlerRequestException {
         Map<String, String> pathParameters = new HashMap<>();
         pathParameters.put(TaskManagerIdPathParameter.KEY, taskManagerId.toString());
         Map<String, List<String>> queryParameters = Collections.emptyMap();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/util/HandlerRequestUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/util/HandlerRequestUtilsTest.java
@@ -83,7 +83,8 @@ public class HandlerRequestUtilsTest extends TestLogger {
 
     private static class TestMessageParameters extends MessageParameters {
 
-        private TestBooleanQueryParameter testBooleanQueryParameter;
+        private final TestBooleanQueryParameter testBooleanQueryParameter =
+                new TestBooleanQueryParameter();
 
         @Override
         public Collection<MessagePathParameter<?>> getPathParameters() {
@@ -92,7 +93,6 @@ public class HandlerRequestUtilsTest extends TestLogger {
 
         @Override
         public Collection<MessageQueryParameter<?>> getQueryParameters() {
-            testBooleanQueryParameter = new TestBooleanQueryParameter();
             return Collections.singletonList(testBooleanQueryParameter);
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/util/HandlerRequestUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/util/HandlerRequestUtilsTest.java
@@ -43,11 +43,12 @@ public class HandlerRequestUtilsTest extends TestLogger {
     public void testGetQueryParameter() throws Exception {
         final Boolean queryParameter =
                 HandlerRequestUtils.getQueryParameter(
-                        new HandlerRequest<>(
+                        HandlerRequest.resolveParametersAndCreate(
                                 EmptyRequestBody.getInstance(),
                                 new TestMessageParameters(),
                                 Collections.emptyMap(),
-                                Collections.singletonMap("key", Collections.singletonList("true"))),
+                                Collections.singletonMap("key", Collections.singletonList("true")),
+                                Collections.emptyList()),
                         TestBooleanQueryParameter.class);
         assertThat(queryParameter, equalTo(true));
     }
@@ -56,11 +57,12 @@ public class HandlerRequestUtilsTest extends TestLogger {
     public void testGetQueryParameterRepeated() throws Exception {
         try {
             HandlerRequestUtils.getQueryParameter(
-                    new HandlerRequest<>(
+                    HandlerRequest.resolveParametersAndCreate(
                             EmptyRequestBody.getInstance(),
                             new TestMessageParameters(),
                             Collections.emptyMap(),
-                            Collections.singletonMap("key", Arrays.asList("true", "false"))),
+                            Collections.singletonMap("key", Arrays.asList("true", "false")),
+                            Collections.emptyList()),
                     TestBooleanQueryParameter.class);
         } catch (final RestHandlerException e) {
             assertThat(e.getMessage(), containsString("Expected only one value"));
@@ -71,11 +73,12 @@ public class HandlerRequestUtilsTest extends TestLogger {
     public void testGetQueryParameterDefaultValue() throws Exception {
         final Boolean allowNonRestoredState =
                 HandlerRequestUtils.getQueryParameter(
-                        new HandlerRequest<>(
+                        HandlerRequest.resolveParametersAndCreate(
                                 EmptyRequestBody.getInstance(),
                                 new TestMessageParameters(),
                                 Collections.emptyMap(),
-                                Collections.singletonMap("key", Collections.emptyList())),
+                                Collections.singletonMap("key", Collections.emptyList()),
+                                Collections.emptyList()),
                         TestBooleanQueryParameter.class,
                         true);
         assertThat(allowNonRestoredState, equalTo(true));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/TestRestHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/TestRestHandler.java
@@ -67,7 +67,7 @@ public class TestRestHandler<
 
     @Override
     protected CompletableFuture<RES> handleRequest(
-            @Nullable HandlerRequest<REQ, M> request, @Nullable G gateway)
+            @Nullable HandlerRequest<REQ> request, @Nullable G gateway)
             throws RestHandlerException {
         final CompletableFuture<RES> result = responseQueue.poll();
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PartitionPathUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PartitionPathUtils.java
@@ -113,17 +113,34 @@ public class PartitionPathUtils {
             throw new TableException("Path should not be null or empty: " + path);
         }
 
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = null;
         for (int i = 0; i < path.length(); i++) {
             char c = path.charAt(i);
             if (needsEscaping(c)) {
-                sb.append('%');
-                sb.append(String.format("%1$02X", (int) c));
-            } else {
+                if (sb == null) {
+                    sb = new StringBuilder(path.length() + 2);
+                    for (int j = 0; j < i; j++) {
+                        sb.append(path.charAt(j));
+                    }
+                }
+                escapeChar(c, sb);
+            } else if (sb != null) {
                 sb.append(c);
             }
         }
+        if (sb == null) {
+            return path;
+        }
         return sb.toString();
+    }
+
+    static StringBuilder escapeChar(char c, StringBuilder sb) {
+        sb.append('%');
+        if (c < 16) {
+            sb.append('0');
+        }
+        sb.append(Integer.toHexString(c).toUpperCase());
+        return sb;
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PartitionPathUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PartitionPathUtils.java
@@ -108,7 +108,7 @@ public class PartitionPathUtils {
      * @param path The path to escape.
      * @return An escaped path name.
      */
-    private static String escapePathName(String path) {
+    static String escapePathName(String path) {
         if (path == null || path.length() == 0) {
             throw new TableException("Path should not be null or empty: " + path);
         }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PartitionPathUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PartitionPathUtilsTest.java
@@ -33,4 +33,49 @@ public class PartitionPathUtilsTest {
             assertEquals(expected, actual);
         }
     }
+
+    @Test
+    public void testEscapePathNameWithHeadControl() {
+        String origin = "[00";
+        String expected = "%5B00";
+        String actual = PartitionPathUtils.escapePathName(origin);
+        assertEquals(expected, actual);
+        assertEquals(origin, PartitionPathUtils.unescapePathName(actual));
+    }
+
+    @Test
+    public void testEscapePathNameWithTailControl() {
+        String origin = "00]";
+        String expected = "00%5D";
+        String actual = PartitionPathUtils.escapePathName(origin);
+        assertEquals(expected, actual);
+        assertEquals(origin, PartitionPathUtils.unescapePathName(actual));
+    }
+
+    @Test
+    public void testEscapePathNameWithMidControl() {
+        String origin = "00:00";
+        String expected = "00%3A00";
+        String actual = PartitionPathUtils.escapePathName(origin);
+        assertEquals(expected, actual);
+        assertEquals(origin, PartitionPathUtils.unescapePathName(actual));
+    }
+
+    @Test
+    public void testEscapePathName() {
+        String origin = "[00:00]";
+        String expected = "%5B00%3A00%5D";
+        String actual = PartitionPathUtils.escapePathName(origin);
+        assertEquals(expected, actual);
+        assertEquals(origin, PartitionPathUtils.unescapePathName(actual));
+    }
+
+    @Test
+    public void testEscapePathNameWithoutControl() {
+        String origin = "0000";
+        String expected = "0000";
+        String actual = PartitionPathUtils.escapePathName(origin);
+        assertEquals(expected, actual);
+        assertEquals(origin, PartitionPathUtils.unescapePathName(actual));
+    }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PartitionPathUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PartitionPathUtilsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link org.apache.flink.table.utils.PartitionPathUtils}. */
+public class PartitionPathUtilsTest {
+
+    @Test
+    public void testEscapeChar() {
+        for (char c = 0; c <= 128; c++) {
+            String expected = "%" + String.format("%1$02X", (int) c);
+            String actual = PartitionPathUtils.escapeChar(c, new StringBuilder()).toString();
+            assertEquals(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This pull request improves performance of file sink on Nexmark q10.

## Brief change log
  - Use more efficient `Integer.toHexString` instead of `String.format`
  - Do not allocate new string when there is no escapable char in the original string
  - Allocate `StringBuilder` depending on the original string length instead of the default value


## Verifying this change

This change added tests and can be verified as follows:
  - Added test `PartitionPathUtilsTest.testEscapeChar` verifying the original behavior of `String.format` is kept

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
